### PR TITLE
fix: golang lint ci failed

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,9 +13,13 @@ jobs:
     name: Golang lint
     runs-on: ubuntu-latest
     steps:
+      - name: Install Go 1.17
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.29
           args: --timeout 3m0s


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

fix: golang lint ci failed

## Description

Just now I found out that one of the contributor's pr(#385 ) failed in ci workflow:
https://github.com/devstream-io/devstream/runs/5814780108?check_suite_focus=true

This problem is not introduced by this pr, but: https://github.com/golangci/golangci-lint-action/issues/434

So the solution here should be:

1. set up `skip-go-installation: true` in v2
2. upgrade `golangci-lint-action` to v3 - (I choose this)
