### PR TITLE
feat(cmd): support  list command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,14 @@ BUILD_PATH=$(patsubst %/,%,$(dir $(MKFILE_PATH)))/build/working_dir
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 GO_BUILD=go build -buildmode=plugin -trimpath -gcflags="all=-N -l"
-
 PLUGINS_CMD_ROOT=./cmd/plugin
 PLUGINS_DIR=$(shell find ${PLUGINS_CMD_ROOT} -name "main.go" -exec dirname {} \;)
 PLUGINS_NAME=$(notdir ${PLUGINS_DIR})
 PLUGIN_SUFFIX=${GOOS}-${GOARCH}_${VERSION}
+
+DTM_INTER_PKG=github.com/devstream-io/devstream/internal/pkg
+GO_LDFLAGS += -X '$(DTM_INTER_PKG)/version.Version=$(VERSION)' \
+		-X '$(DTM_INTER_PKG)/list.PluginsName=$(PLUGINS_NAME)'
 
 ifeq ($(GOOS),linux)
 	MD5SUM=md5sum
@@ -31,7 +34,7 @@ clean: ## Remove dtm and plugins. It's best to run a "clean" before "build".
 
 .PHONY: build-core
 build-core: fmt vet mod-tidy ## Build dtm core only, without plugins, locally.
-	go build -trimpath -gcflags="all=-N -l" -ldflags "-X github.com/devstream-io/devstream/internal/pkg/version.Version=${VERSION}" -o dtm-${GOOS}-${GOARCH} ./cmd/devstream/
+	go build -trimpath -gcflags="all=-N -l" -ldflags "$(GO_LDFLAGS)" -o dtm-${GOOS}-${GOARCH} ./cmd/devstream/
 	rm -f dtm
 	cp dtm-${GOOS}-${GOARCH} dtm
 

--- a/cmd/devstream/list.go
+++ b/cmd/devstream/list.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/devstream-io/devstream/internal/pkg/list"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+var listCMD = &cobra.Command{
+	Use:   "list",
+	Short: "This command lists all of the plugins",
+	Long: `This command lists all of the plugins.
+eg.
+- dtm list plugins`,
+	Run: listCMDFunc,
+}
+
+func listCMDFunc(cmd *cobra.Command, args []string) {
+	if err := validateListCMDArgs(args); err != nil {
+		log.Fatal(err)
+	}
+
+	listAction := list.Action(args[0])
+	log.Debugf("The list action is: %s.", listAction)
+	if err := list.ExecuteAction(listAction); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func validateListCMDArgs(args []string) error {
+	// "plugins"/ maybe it will be "core" in future.
+	if len(args) != 1 {
+		return fmt.Errorf("got illegal args count (expect 1, got %d). "+
+			"See `help` command for more info", len(args))
+	}
+	listAction := list.Action(args[0])
+	if !list.IsValideAction(listAction) {
+		return fmt.Errorf("invalide Develop Action")
+	}
+	return nil
+}
+
+// TODO Use `--filter=someone` (can support regex) to filter plugins on feature,
+// TODO Use `--group=somegroup` to filter the specified groups on feature
+// func init() {
+// 	developCMD.PersistentFlags().StringVarP(&filter, "filter", "f", "", "filter plugins; support regex ")
+// 	developCMD.PersistentFlags().StringVarP(&group, "group", "g", "", "filter the specified groups; support regex")
+// }

--- a/cmd/devstream/main.go
+++ b/cmd/devstream/main.go
@@ -51,6 +51,7 @@ func init() {
 	rootCMD.AddCommand(destroyCMD)
 	rootCMD.AddCommand(verifyCMD)
 	rootCMD.AddCommand(developCMD)
+	rootCMD.AddCommand(listCMD)
 }
 
 func initConfig() {

--- a/internal/pkg/list/list.go
+++ b/internal/pkg/list/list.go
@@ -1,0 +1,38 @@
+package list
+
+import (
+	"github.com/devstream-io/devstream/internal/pkg/list/plugins"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+// list is the version of DevStream.
+// Assign the value when building with the -X parameter. Example:
+// -X github.com/devstream-io/devstream/internal/pkg/list.PluginsName=${PLUGINS_NAME}
+// See the Makefile for more info.
+
+var PluginsName string
+
+type Action string
+
+const (
+	ActionListPlugin Action = "plugins"
+)
+
+var ActionSet = map[Action]struct{}{
+	ActionListPlugin: {},
+}
+
+func IsValideAction(action Action) bool {
+	_, ok := ActionSet[action]
+	return ok
+}
+
+func ExecuteAction(action Action) error {
+	switch action {
+	case ActionListPlugin:
+		log.Debugf("Action: %s.", ActionListPlugin)
+		return plugins.List(PluginsName)
+	default:
+		panic("This should be never happen!")
+	}
+}

--- a/internal/pkg/list/plugins/list.go
+++ b/internal/pkg/list/plugins/list.go
@@ -1,0 +1,17 @@
+package plugins
+
+import (
+	"fmt"
+	"strings"
+	// "github.com/spf13/viper"
+	// "github.com/devstream-io/devstream/pkg/util/log"
+)
+
+// List all of plugins name
+func List(PluginsName string) error {
+	listPluginsName := strings.Fields(PluginsName)
+	for _, pluginName := range listPluginsName {
+		fmt.Println(pluginName)
+	}
+	return nil
+}


### PR DESCRIPTION
# Summary

View all supported plugins with the command:
 `dtm list plugins`
and in Makefile: 
`ldflags  parameter` is too long, extract the `DEVSTREAM_INTER_PKG` and `GO_LDFLAGS` parameter



### Related Issues

#384 


### New Behavior

![image](https://user-images.githubusercontent.com/17695185/161935191-3c714899-0259-4b26-8b21-1893cac75e8b.png)

![image](https://user-images.githubusercontent.com/17695185/161939351-2b1eac5e-d8d8-44ed-8763-7d41c638a0f3.png)
