### PR TITLE
Feat: Support default config print logic by @summingyu

### DIFF
--- a/cmd/devstream/list/list.go
+++ b/cmd/devstream/list/list.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -15,6 +16,7 @@ var PluginsName string
 // List all of plugins name
 func List() {
 	listPluginsName := strings.Fields(PluginsName)
+	sort.Strings(listPluginsName)
 	for _, pluginName := range listPluginsName {
 		fmt.Println(pluginName)
 	}

--- a/internal/pkg/show/config/config.go
+++ b/internal/pkg/show/config/config.go
@@ -10,14 +10,20 @@ import (
 
 var pluginDefaultConfigs = map[string]string{
 	"argocd":                         plugin.ArgocdDefaultConfig,
-	"gitlabci-generic":               plugin.GitlabCIGenericDefaultConfig,
 	"argocdapp":                      plugin.ArgocdappDefaultConfig,
+	"devlake":                        plugin.DevlakeDefaultConfig,
 	"github-repo-scaffolding-golang": plugin.GithubRepoScaffoldingGolangDefaultConfig,
 	"githubactions-golang":           plugin.GithubActionsGolangDefaultConfig,
-	"devlake":                        plugin.DevlakeDefaultConfig,
-	"githubactions-python":           plugin.GithubActionsPythonDefaultConfig,
 	"githubactions-nodejs":           plugin.GithubActionsNodejsDefaultConfig,
+	"githubactions-python":           plugin.GithubActionsPythonDefaultConfig,
+	"gitlabci-generic":               plugin.GitlabCIGenericDefaultConfig,
 	"gitlabci-golang":                plugin.GitlabCIGolangDefaultConfig,
+	"jenkins":                        plugin.JenkinsDefaultConfig,
+	"jira-github-integ":              plugin.JiraGithubDefaultConfig,
+	"kube-prometheus":                plugin.KubePrometheusDefaultConfig,
+	"openldap":                       plugin.OpenldapDefaultConfig,
+	"trello-github-integ":            plugin.TrelloGithubDefaultConfig,
+	"trello":                         plugin.TrelloDefaultConfig,
 }
 
 func Show() error {

--- a/internal/pkg/show/config/plugin/jenkins.go
+++ b/internal/pkg/show/config/plugin/jenkins.go
@@ -1,0 +1,38 @@
+package plugin
+
+var JenkinsDefaultConfig = `tools:
+# name of the instance with jenkins
+- name: jenkins-dev
+  # name of the plugin
+  plugin: jenkins
+  # options for the plugin
+  options:
+    # need to create the namespace or not, default: false
+    create_namespace: false
+    # Helm repo information
+    repo:
+      # name of the Helm repo
+      name: jenkins
+      # url of the Helm repo
+      url: https://charts.jenkins.io
+    # Helm chart information
+    chart:
+      # name of the chart
+      chart_name: jenkins/jenkins
+      # release name of the chart
+      release_name: dev
+      # k8s namespace where jenkins will be installed
+      namespace: jenkins
+      # whether to wait for the release to be deployed or not
+      wait: true
+      # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 5m0s
+      timeout: 5m
+      # whether to perform a CRD upgrade during installation
+      upgradeCRDs: true
+      # custom configuration (Optional). You can refer to [Jenkins values.yaml](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml)
+      values_yaml: |
+        persistence:
+          storageClass: jenkins-pv
+        serviceAccount:
+          create: false
+          name: jenkins`

--- a/internal/pkg/show/config/plugin/jira-github-integ.go
+++ b/internal/pkg/show/config/plugin/jira-github-integ.go
@@ -1,0 +1,20 @@
+package plugin
+
+var JiraGithubDefaultConfig = `tools:
+- name: default
+  # name of the plugin
+  plugin: jira-github-integ
+  # options for the plugin
+  options:
+    # the repo's owner
+    owner: YOUR_GITHUB_USERNAME
+    # the repo where you'd like to setup GitHub Actions
+    repo: YOUR_REPO_NAME
+    # "base url: https://id.atlassian.net"
+    jiraBaseUrl: https://JIRA_ID.atlassian.net
+    # "need real user email in cloud Jira"
+    jiraUserEmail: JIRA_USER_EMAIL
+    # "get it from project url, like 'HEAP' from https://merico.atlassian.net/jira/software/projects/HEAP/pages"
+    jiraProjectKey: JIRA_PROJECT_KEY 
+    # main branch of the repo (to which branch the plugin will submit the workflows)
+    branch: main`

--- a/internal/pkg/show/config/plugin/kube-prometheus.go
+++ b/internal/pkg/show/config/plugin/kube-prometheus.go
@@ -1,0 +1,34 @@
+package plugin
+
+var KubePrometheusDefaultConfig = `tools:
+# name of the instance with kube-prometheus
+- name: kube-prometheus-dev
+  # name of the plugin
+  plugin: kube-prometheus
+  # options for the plugin
+  options:
+    # need to create the namespace or not, default: false
+    create_namespace: false
+    # Helm repo information
+    repo:
+      # name of the Helm repo
+      name: prometheus-community
+      # url of the Helm repo
+      url: https://prometheus-community.github.io/helm-charts
+    # Helm chart information
+    chart:
+      # name of the chart
+      chart_name: prometheus-community/kube-prometheus-stack
+      # release name of the chart
+      release_name: dev
+      # k8s namespace where kube-prometheus will be installed
+      namespace: monitoring
+      # whether to wait for the release to be deployed or not
+      wait: true
+      # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 5m0s
+      timeout: 5m
+      # whether to perform a CRD upgrade during installation
+      upgradeCRDs: true
+      # custom configuration (Optional). You can refer to [kube-prometheus-stack values.yaml](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml)
+      values_yaml: |
+        namespaceOverride: "monitoring"`

--- a/internal/pkg/show/config/plugin/openldap.go
+++ b/internal/pkg/show/config/plugin/openldap.go
@@ -1,0 +1,46 @@
+package plugin
+
+var OpenldapDefaultConfig = `tools:
+- name: openldap
+  # name of the plugin
+  plugin: openldap
+  options:
+    # need to create the namespace or not, default: false
+    create_namespace: true
+    repo:
+      # name of the Helm repo
+      name: helm-openldap
+      # url of the Helm repo
+      url: https://jp-gouin.github.io/helm-openldap/
+    # Helm chart information
+    chart:
+      # name of the chart
+      chart_name: helm-openldap/openldap-stack-ha
+      # release name of the chart
+      release_name: openldap
+      # k8s namespace where OpenLDAP will be installed
+      namespace: openldap
+      # whether to wait for the release to be deployed or not
+      wait: true
+      # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 5m0s
+      timeout: 5m
+      # custom configuration (Optional). You can refer to https://github.com/jp-gouin/helm-openldap/blob/master/values.yaml
+      values_yaml: |
+        replicaCount: 1
+        service: 
+          type: NodePort  
+        env:
+          LDAP_ORGANISATION: "DevStream Inc."
+          LDAP_DOMAIN: "devstream.org"
+        persistence:
+          enabled: false
+        adminPassword: Not@SecurePassw0rd
+        configPassword: Not@SecurePassw0rd
+
+        ltb-passwd:
+          enabled : false
+
+        phpldapadmin:
+          enabled: true
+          ingress:
+            enabled: false`

--- a/internal/pkg/show/config/plugin/trello-github-integ.go
+++ b/internal/pkg/show/config/plugin/trello-github-integ.go
@@ -1,0 +1,29 @@
+package plugin
+
+var TrelloGithubDefaultConfig = `tools:
+- name: my-trello-board
+  # name of the plugin
+  plugin: trello
+  dependsOn: ["demo.github-repo-scaffolding-golang"]
+  options:
+    owner: YOUR_GITHUB_USERNAME
+    repo: YOUR_REPO_NAME
+    kanbanBoardName: KANBAN_BOARD_NAME
+- name: trello-github
+  # name of the plugin
+  plugin: trello-github-integ
+  # optional; if specified, dtm will make sure the dependency is applied first before handling this tool.
+  dependsOn: [ "my-trello-board.trello" ]
+  # options for the plugin
+  options:
+    # the repo's owner. It should be case-sensitive here; strictly use your GitHub user name; please change the value below.
+    owner: YOUR_GITHUB_USERNAME
+    # the repo where you'd like to setup GitHub Actions; please change the value below.
+    repo: YOUR_REPO_NAME
+    # reference parameters come from dependency, their usage will be explained later
+    boardId: ${{ my-trello-board.trello.outputs.boardId }}
+    todoListId: ${{ my-trello-board.trello.outputs.todoListId }}
+    doingListId: ${{ my-trello-board.trello.outputs.doingListId }}
+    doneListId: ${{ my-trello-board.trello.outputs.doneListId }}
+    # main branch of the repo (to which branch the plugin will submit the workflows)
+    branch: main`

--- a/internal/pkg/show/config/plugin/trello.go
+++ b/internal/pkg/show/config/plugin/trello.go
@@ -1,0 +1,14 @@
+package plugin
+
+var TrelloDefaultConfig = `tools:
+- name: my-trello-board
+  # name of the plugin
+  plugin: trello
+  # options for the plugin, checkout the version from the GitHub releases
+  options:
+    # the repo's owner
+    owner: YOUR_GITHUB_USERNAME
+    # for which repo this board will be used
+    repo: YOUR_REPO_NAME
+    # the Tello board name. If empty, use owner/repo as the board's name.
+    kanbanBoardName: KANBAN_BOARD_NAME`


### PR DESCRIPTION

1. Support default config print logic

 - [x] "jenkins"                      
- [x] "jira-github-integ"          
- [x] "kube-prometheus":                
- [x] "openldap":                     
- [x] "trello-github-integ":           
- [x] "trello": 

2. Sorting the output of the list command

## Related Issues
#383