### PR TITLE
feat: outputs support interpolation; add more e2e tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,4 +1,5 @@
 name: e2e test
+
 on:
   push:
     branches:
@@ -12,6 +13,14 @@ on:
       - 'test/**'
       - 'hack/e2e/**'
       - 'hack/terraform/**'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  TRELLO_API_KEY: ${{ secrets.TRELLO_API_KEY }}
+  TRELLO_TOKEN: ${{ secrets.TRELLO_TOKEN }}
+
 jobs:
   e2e-test:
     if: github.repository == 'devstream-io/devstream'
@@ -56,7 +65,10 @@ jobs:
         run: ./dtm apply -f ./test/e2e/yaml/e2e-config.yaml -y
       - name: apply twice
         run: ./dtm apply -f ./test/e2e/yaml/e2e-config.yaml -y
+      - name: check if pod is ready
+      run: while [[ $(kubectl get pods -l app=dtm-e2e-go -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do echo "pod not ready yet..."; sleep 3; done
+        timeout-minutes: 10
       - name: verify
         run: ./dtm verify -f ./test/e2e/yaml/e2e-config.yaml
       - name: clean
-        run: ./dtm delete -f ./test/e2e/yaml/e2e-config.yaml --force -y
+        run: ./dtm delete -f ./test/e2e/yaml/e2e-config.yaml -y

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -15,11 +15,11 @@ on:
       - 'hack/terraform/**'
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-  TRELLO_API_KEY: ${{ secrets.TRELLO_API_KEY }}
-  TRELLO_TOKEN: ${{ secrets.TRELLO_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.E2E_GITHUB_TOKEN }}
+  DOCKERHUB_USERNAME: ${{ secrets.E2E_DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.E2E_DOCKERHUB_TOKEN }}
+  TRELLO_API_KEY: ${{ secrets.E2E_TRELLO_API_KEY }}
+  TRELLO_TOKEN: ${{ secrets.E2E_TRELLO_TOKEN }}
 
 jobs:
   e2e-test:

--- a/internal/pkg/pluginengine/outputs_test.go
+++ b/internal/pkg/pluginengine/outputs_test.go
@@ -4,64 +4,51 @@ import (
 	"testing"
 )
 
-type stripOutputReferencePrefixAndSuffixTest struct {
-	arg      string
+type getToolNamePluginOutputKeyTest struct {
+	arg    string
+	match  bool
+	name   string
+	plugin string
+	key    string
+}
+
+var getToolNamePluginOutputKeyTests = []getToolNamePluginOutputKeyTest{
+	{"${{a.b.outputs.d}}", true, "a", "b", "d"},
+	{"prefix${{a.b.outputs.d}}suffix", true, "a", "b", "d"},
+	{"${{  a.b.outputs.d  }}", true, "a", "b", "d"},
+	{"${{  a.b.c  }}", false, "", "", ""},
+}
+
+func TestGetToolNamePluginOutputKey(t *testing.T) {
+	for _, test := range getToolNamePluginOutputKeyTests {
+		match, name, plugin, key := getToolNamePluginOutputKey(test.arg)
+		if match != test.match || name != test.name || plugin != test.plugin || key != test.key {
+			t.Errorf(
+				"Output %t, %s, %s, %s not equal to expected %t, %s, %s, %s. Input: %s.",
+				match, name, plugin, key,
+				test.match, test.name, test.plugin, test.key,
+				test.arg,
+			)
+		}
+	}
+}
+
+type replaceOutputKeyWithValueTest struct {
+	arg1     string
+	arg2     string
 	expected string
 }
 
-var stripOutputReferencePrefixAndSuffixTests = []stripOutputReferencePrefixAndSuffixTest{
-	{"${{a.b.c.d}}", "a.b.c.d"},
-	{"${{ a.b.c.d }}", "a.b.c.d"},
-	{"${{  a.b.c.d  }}", "a.b.c.d"},
-	{"${{  a.b.c  }}", "a.b.c"},
-}
-
-func TestStripOutputReferencePrefixAndSuffix(t *testing.T) {
-	for _, test := range stripOutputReferencePrefixAndSuffixTests {
-		if got := stripOutputReferencePrefixAndSuffix(test.arg); got != test.expected {
-			t.Errorf("Output %s not equal to expected %s. Input: %s.", got, test.expected, test.arg)
-		}
-	}
-}
-
-type isValidOutputsReferenceTest struct {
-	arg      string
-	expected bool
-}
-
-var isValidOutputsReferenceTests = []isValidOutputsReferenceTest{
-	{"${{a.b.c.d}}", true},
-	{"${{ a.b.c.d }}", true},
-	{"${{  a.b.c.d  }}", true},
-	{"${{ a.b.c }}", false},
-	{"${{ a.b.c.d.e }}", true},
-	{"${ a.b.c.d.e }", false},
-	{"{{ a.b.c.d.e }}", false},
+var replaceOutputKeyWithValueTests = []replaceOutputKeyWithValueTest{
+	{"${{a.b.outputs.d}}", "value", "value"},
+	{"prefix/${{ a.b.outputs.d }}/suffix", "value", "prefix/value/suffix"},
+	{"${{a.b.c}}", "value", "${{a.b.c}}"},
 }
 
 func TestIsValidOutputsReference(t *testing.T) {
-	for _, test := range isValidOutputsReferenceTests {
-		if got := isValidOutputsReferenceFormat(test.arg); got != test.expected {
-			t.Errorf("Output %t not equal to expected %t. Input: %s.", got, test.expected, test.arg)
-		}
-	}
-}
-
-type getToolNamePluginKindAndOutputReferenceKeyTest struct {
-	arg       string
-	expected1 string
-	expected2 string
-	expected3 string
-}
-
-var getToolNamePluginKindAndOutputReferenceKeyTests = []getToolNamePluginKindAndOutputReferenceKeyTest{
-	{"name.kind.outputs.key", "name", "kind", "key"},
-}
-
-func TestGetToolNamePluginKindAndOutputReferenceKey(t *testing.T) {
-	for _, test := range getToolNamePluginKindAndOutputReferenceKeyTests {
-		if got1, got2, got3 := getToolNamePluginKindAndOutputReferenceKey(test.arg); got1 != test.expected1 || got2 != test.expected2 || got3 != test.expected3 {
-			t.Errorf("Output %s, %s, %s not equal to expected %s, %s, %s.", got1, got2, got3, test.expected1, test.expected2, test.expected3)
+	for _, test := range replaceOutputKeyWithValueTests {
+		if got := replaceOutputKeyWithValue(test.arg1, test.arg2); got != test.expected {
+			t.Errorf("Output %s not equal to expected %s. Input: %s, %s.", got, test.expected, test.arg1, test.arg2)
 		}
 	}
 }

--- a/internal/pkg/pluginengine/pluginengine_test.go
+++ b/internal/pkg/pluginengine/pluginengine_test.go
@@ -121,6 +121,31 @@ var _ = Describe("Pluginengine", func() {
 		Expect(dependantOptions).To(Equal(expectResult))
 	})
 
+	It("should handle output interpolation correctly", func() {
+		trelloState := statemanager.State{
+			Name:    "mytrelloboard",
+			Plugin:  "trello",
+			Options: map[string]interface{}{},
+			Resource: map[string]interface{}{
+				"outputs": map[string]interface{}{
+					"boardId": expectedBoardId,
+				},
+			},
+		}
+		err = smgr.AddState(trelloKey, trelloState)
+		Expect(err).NotTo(HaveOccurred())
+
+		dependantOptions := map[string]interface{}{
+			"boardId": fmt.Sprintf("prefix/${{ %s.%s.outputs.boardId }}/suffix", trelloToolName, trelloPluginKind),
+		}
+		expectResult := map[string]interface{}{
+			"boardId": fmt.Sprintf("prefix/%s/suffix", expectedBoardId),
+		}
+		errs := pluginengine.HandleOutputsReferences(smgr, dependantOptions)
+		Expect(len(errs)).To(BeZero())
+		Expect(dependantOptions).To(Equal(expectResult))
+	})
+
 	It("should give an error when output doesn't exist in the state", func() {
 		trelloState := statemanager.State{
 			Name:     "mytrelloboard",

--- a/test/e2e/yaml/e2e-config.yaml
+++ b/test/e2e/yaml/e2e-config.yaml
@@ -1,25 +1,54 @@
 tools:
-  - name: argocd
-    plugin: argocd
-    options:
-      # need to create the namespace or not, default: false
-      create_namespace: true
-      repo:
-        # name of the Helm repo
-        name: argo
-        # url of the Helm repo
-        url: https://argoproj.github.io/argo-helm
-      # Helm chart information
-      chart:
-        # name of the chart
-        chart_name: argo/argo-cd
-        # release name of the chart
-        release_name: argocd
-        # k8s namespace where ArgoCD will be installed
-        namespace: argocd
-        # whether to wait for the release to be deployed or not
-        wait: true
-        # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 5m0s
-        timeout: 5m
-        # whether to perform a CRD upgrade during installation
-        upgradeCRDs: true
+- name: go-webapp-repo
+  plugin: github-repo-scaffolding-golang
+  options:
+    owner: IronCore864
+    repo: dtm-e2e-go
+    branch: main
+    image_repo: ironcore864/dtm-e2e-go
+- name: golang-demo-actions
+  plugin: githubactions-golang
+  dependsOn: ["go-webapp-repo.github-repo-scaffolding-golang"]
+  options:
+    owner: ${{go-webapp-repo.github-repo-scaffolding-golang.outputs.owner}}
+    repo: ${{go-webapp-repo.github-repo-scaffolding-golang.outputs.repo}}
+    language:
+      name: go
+      version: "1.17"
+    branch: main
+    build:
+      enable: True
+    test:
+      enable: True
+      coverage:
+        enable: True
+    docker:
+      enable: True
+- name: argocd
+  plugin: argocd
+  options:
+    create_namespace: true
+    repo:
+      name: argo
+      url: https://argoproj.github.io/argo-helm
+    chart:
+      chart_name: argo/argo-cd
+      release_name: argocd
+      namespace: argocd
+      wait: true
+      timeout: 10m
+      upgradeCRDs: true
+- name: go-webapp-argocd-deploy
+  plugin: argocdapp
+  dependsOn: ["argocd.argocd", "go-webapp-repo.github-repo-scaffolding-golang"]
+  options:
+    app:
+      name: ${{go-webapp-repo.github-repo-scaffolding-golang.outputs.repo}}
+      namespace: argocd
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: default
+    source:
+      valuefile: values.yaml
+      path: helm/${{go-webapp-repo.github-repo-scaffolding-golang.outputs.repo}}
+      repoURL: ${{go-webapp-repo.github-repo-scaffolding-golang.outputs.repoURL}}


### PR DESCRIPTION
# Summary

## Description

- New feature: now outputs support string interpolation. For example: `helm/${{ repo.github-repo-scaffolding-go.outputs.repo }}` can be used as a value.
- e2e tests: added repo scaffolding -> github actions -> argocd -> argocd app -> verify pod.