### PR TITLE
Fix destroy force delete order issue

### DIFF
--- a/internal/pkg/plugin/githubactions/common.go
+++ b/internal/pkg/plugin/githubactions/common.go
@@ -8,9 +8,13 @@ func GetLanguage(l *Language) string {
 	return fmt.Sprintf("%s-%s", l.Name, l.Version)
 }
 
-func BuildState(owner, repo string) map[string]interface{} {
+func BuildState(owner, org, repo string) map[string]interface{} {
 	res := make(map[string]interface{})
-	res["workflowDir"] = fmt.Sprintf("/repos/%s/%s/contents/.github/workflows", owner, repo)
+	if owner != "" {
+		res["workflowDir"] = fmt.Sprintf("/repos/%s/%s/contents/.github/workflows", owner, repo)
+	} else {
+		res["workflowDir"] = fmt.Sprintf("/repos/%s/%s/contents/.github/workflows", org, repo)
+	}
 	return res
 }
 

--- a/internal/pkg/plugin/githubactions/golang/create.go
+++ b/internal/pkg/plugin/githubactions/golang/create.go
@@ -60,5 +60,5 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		}
 	}
 
-	return ga.BuildState(opts.Owner, opts.Repo), nil
+	return ga.BuildState(opts.Owner, opts.Org, opts.Repo), nil
 }

--- a/internal/pkg/plugin/githubactions/golang/update.go
+++ b/internal/pkg/plugin/githubactions/golang/update.go
@@ -72,5 +72,5 @@ func Update(options map[string]interface{}) (map[string]interface{}, error) {
 		}
 	}
 
-	return ga.BuildState(opts.Owner, opts.Repo), nil
+	return ga.BuildState(opts.Owner, opts.Org, opts.Repo), nil
 }

--- a/internal/pkg/plugin/githubactions/nodejs/create.go
+++ b/internal/pkg/plugin/githubactions/nodejs/create.go
@@ -46,5 +46,5 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		}
 	}
 
-	return githubactions.BuildState(opts.Owner, opts.Repo), nil
+	return githubactions.BuildState(opts.Owner, opts.Org, opts.Repo), nil
 }

--- a/internal/pkg/plugin/githubactions/nodejs/update.go
+++ b/internal/pkg/plugin/githubactions/nodejs/update.go
@@ -51,5 +51,5 @@ func Update(options map[string]interface{}) (map[string]interface{}, error) {
 		}
 	}
 
-	return githubactions.BuildState(opts.Owner, opts.Repo), nil
+	return githubactions.BuildState(opts.Owner, opts.Org, opts.Repo), nil
 }

--- a/internal/pkg/plugin/githubactions/python/create.go
+++ b/internal/pkg/plugin/githubactions/python/create.go
@@ -44,5 +44,5 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		}
 	}
 
-	return ga.BuildState(opts.Owner, opts.Repo), nil
+	return ga.BuildState(opts.Owner, opts.Org, opts.Repo), nil
 }

--- a/internal/pkg/plugin/githubactions/python/update.go
+++ b/internal/pkg/plugin/githubactions/python/update.go
@@ -50,5 +50,5 @@ func Update(options map[string]interface{}) (map[string]interface{}, error) {
 		}
 	}
 
-	return ga.BuildState(opts.Owner, opts.Repo), nil
+	return ga.BuildState(opts.Owner, opts.Org, opts.Repo), nil
 }

--- a/internal/pkg/plugin/reposcaffolding/github/golang/golang.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/golang.go
@@ -209,12 +209,18 @@ func replaceAppNameInPathStr(filePath, appName string) (string, error) {
 func buildState(opts *Options) map[string]interface{} {
 	res := make(map[string]interface{})
 	res["owner"] = opts.Owner
+	res["org"] = opts.Org
 	res["repoName"] = opts.Repo
 
 	outputs := make(map[string]interface{})
 	outputs["owner"] = opts.Owner
+	outputs["org"] = opts.Org
 	outputs["repo"] = opts.Repo
-	outputs["repoURL"] = fmt.Sprintf("https://github.com/%s/%s.git", opts.Owner, opts.Repo)
+	if opts.Owner != "" {
+		outputs["repoURL"] = fmt.Sprintf("https://github.com/%s/%s.git", opts.Owner, opts.Repo)
+	} else {
+		outputs["repoURL"] = fmt.Sprintf("https://github.com/%s/%s.git", opts.Org, opts.Repo)
+	}
 	res["outputs"] = outputs
 
 	return res

--- a/internal/pkg/plugin/reposcaffolding/github/golang/read.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/read.go
@@ -27,11 +27,6 @@ func Read(options map[string]interface{}) (map[string]interface{}, error) {
 }
 
 func buildReadState(opts *Options) (map[string]interface{}, error) {
-	// var owner = opts.Owner
-	// if opts.Org != "" {
-	// 	owner = opts.Org
-	// }
-
 	ghOptions := &github.Option{
 		Owner:    opts.Owner,
 		Org:      opts.Org,

--- a/internal/pkg/plugin/reposcaffolding/github/golang/read.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/read.go
@@ -27,10 +27,10 @@ func Read(options map[string]interface{}) (map[string]interface{}, error) {
 }
 
 func buildReadState(opts *Options) (map[string]interface{}, error) {
-	var owner = opts.Owner
-	if opts.Org != "" {
-		owner = opts.Org
-	}
+	// var owner = opts.Owner
+	// if opts.Org != "" {
+	// 	owner = opts.Org
+	// }
 
 	ghOptions := &github.Option{
 		Owner:    opts.Owner,
@@ -53,14 +53,24 @@ func buildReadState(opts *Options) (map[string]interface{}, error) {
 	}
 
 	res := make(map[string]interface{})
-	res["owner"] = owner
+	res["owner"] = opts.Owner
+	res["org"] = opts.Org
 	res["repoName"] = *repo.Name
 
 	outputs := make(map[string]interface{})
-	outputs["owner"] = owner
-	outputs["repo"] = opts.Repo
-	outputs["repoURL"] = fmt.Sprintf("https://github.com/%s/%s.git", opts.Owner, opts.Repo)
 
+	if opts.Owner == "" {
+		outputs["owner"] = opts.Owner
+	} else {
+		outputs["owner"] = *repo.Owner.Login
+	}
+	if opts.Org == "" {
+		outputs["org"] = opts.Org
+	} else {
+		outputs["org"] = *repo.Organization.Login
+	}
+	outputs["repo"] = opts.Repo
+	outputs["repoURL"] = *repo.CloneURL
 	res["outputs"] = outputs
 
 	return res, nil

--- a/internal/pkg/pluginengine/change.go
+++ b/internal/pkg/pluginengine/change.go
@@ -60,11 +60,7 @@ func getChanges(smgr statemanager.Manager, cfg *configloader.Config, commandType
 	if commandType == CommandApply {
 		changes, err = changesForApply(smgr, cfg)
 	} else if commandType == CommandDelete {
-		if isForceDelete {
-			changes = changesForForceDelete(smgr, cfg)
-		} else {
-			changes = changesForDelete(smgr, cfg)
-		}
+		changes, err = changesForDelete(smgr, cfg, isForceDelete)
 	} else {
 		log.Fatalf("That's impossible!")
 	}
@@ -172,10 +168,11 @@ func handleResult(smgr statemanager.Manager, change *Change) error {
 
 	key := statemanager.StateKeyGenerateFunc(change.Tool)
 	state := statemanager.State{
-		Name:     change.Tool.Name,
-		Plugin:   change.Tool.Plugin,
-		Options:  change.Tool.Options,
-		Resource: change.Result.ReturnValue,
+		Name:      change.Tool.Name,
+		Plugin:    change.Tool.Plugin,
+		DependsOn: change.Tool.DependsOn,
+		Options:   change.Tool.Options,
+		Resource:  change.Result.ReturnValue,
 	}
 	err := smgr.AddState(key, state)
 	if err != nil {

--- a/internal/pkg/pluginengine/cmd_destroy.go
+++ b/internal/pkg/pluginengine/cmd_destroy.go
@@ -4,22 +4,18 @@ import (
 	"errors"
 	"os"
 
-	"github.com/devstream-io/devstream/internal/pkg/configloader"
 	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
 func Destroy(continueDirectly bool) error {
-	emptyConfig := new(configloader.Config)
-
 	smgr, err := statemanager.NewManager()
 	if err != nil {
 		log.Debugf("Failed to get the manager: %s.", err)
 		return err
 	}
 
-	// GetChangesForApply with the empty config will return the changes all with "delete" action.
-	changes, err := GetChangesForApply(smgr, emptyConfig)
+	changes, err := GetChangesForDestroy(smgr)
 	if err != nil {
 		log.Debugf("Get changes failed: %s.", err)
 		return err

--- a/internal/pkg/statemanager/manager_test.go
+++ b/internal/pkg/statemanager/manager_test.go
@@ -43,6 +43,31 @@ var _ = Describe("Statemanager", func() {
 			Expect(stateC).To(BeZero())
 		})
 
+		It("Should get the state list", func() {
+			key := statemanager.StateKey("a_githubactions")
+			stateA := statemanager.State{
+				Name:     "a",
+				Plugin:   "githubactions",
+				Options:  map[string]interface{}{"a": "value"},
+				Resource: map[string]interface{}{"a": "value"},
+			}
+			err = smgr.AddState(key, stateA)
+			Expect(err).NotTo(HaveOccurred())
+
+			key = statemanager.StateKey("b_githubactions")
+			stateB := statemanager.State{
+				Name:     "b",
+				Plugin:   "githubactions",
+				Options:  map[string]interface{}{"b": "value"},
+				Resource: map[string]interface{}{"b": "value"},
+			}
+			err = smgr.AddState(key, stateB)
+			Expect(err).NotTo(HaveOccurred())
+
+			stateList := smgr.GetStatesMap().ToList()
+			Expect(stateList).To(Equal([]statemanager.State{stateA, stateB}))
+		})
+
 		AfterEach(func() {
 			err = os.RemoveAll(local.DefaultStateFile)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/pkg/statemanager/state.go
+++ b/internal/pkg/statemanager/state.go
@@ -13,10 +13,11 @@ import (
 
 // State is the single component's state.
 type State struct {
-	Name     string
-	Plugin   string
-	Options  map[string]interface{}
-	Resource map[string]interface{}
+	Name      string
+	Plugin    string
+	DependsOn []string
+	Options   map[string]interface{}
+	Resource  map[string]interface{}
 }
 
 type StatesMap struct {
@@ -36,6 +37,15 @@ func (s StatesMap) DeepCopy() StatesMap {
 		return true
 	})
 	return newStatesMap
+}
+
+func (s StatesMap) ToList() []State {
+	var res []State
+	s.Range(func(key, value interface{}) bool {
+		res = append(res, value.(State))
+		return true
+	})
+	return res
 }
 
 func (s StatesMap) Format() []byte {

--- a/test/e2e/yaml/e2e-config.yaml
+++ b/test/e2e/yaml/e2e-config.yaml
@@ -2,7 +2,6 @@ tools:
 - name: go-webapp-repo
   plugin: github-repo-scaffolding-golang
   options:
-    owner: ""
     org: devstream-io
     repo: dtm-e2e-go
     branch: main
@@ -11,7 +10,7 @@ tools:
   plugin: githubactions-golang
   dependsOn: ["go-webapp-repo.github-repo-scaffolding-golang"]
   options:
-    owner: ${{go-webapp-repo.github-repo-scaffolding-golang.outputs.owner}}
+    org: ${{go-webapp-repo.github-repo-scaffolding-golang.outputs.org}}
     repo: ${{go-webapp-repo.github-repo-scaffolding-golang.outputs.repo}}
     language:
       name: go


### PR DESCRIPTION
# Summary

## Key Points

- [x] This is a breaking change.

## Description

- added dependsOn into state
- added a new method to StatesMap so that it can be converted to a list (used for easy sorting)
- fixed the order issue with destroy/force delete
- fixed failed e2e-test and org/owner related issue

### Related Issues

Closes #402 

### Current Behavior

See issue #402 

### New Behavior

Destroy and force delete now honor the dependsOn settings.
