### PR TITLE
ci: use the test account to run the e2e

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -1,4 +1,4 @@
-name: Automated Release
+name: automated release
 on:
   release:
     types: [published]

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -15,7 +15,8 @@ on:
       - 'hack/terraform/**'
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Do NOT use the GITHUB_TOKEN here, see https://github.com/devstream-io/devstream/pull/414 for more info.
+  GITHUB_TOKEN: ${{ secrets.E2E_GITHUB_TOKEN }}
   DOCKERHUB_USERNAME: ${{ secrets.E2E_DOCKERHUB_USERNAME }}
   DOCKERHUB_TOKEN: ${{ secrets.E2E_DOCKERHUB_TOKEN }}
   TRELLO_API_KEY: ${{ secrets.E2E_TRELLO_API_KEY }}

--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -1,4 +1,4 @@
-name: lint-commit-message
+name: lint commit message
 on: [ push, pull_request ]
 
 jobs:

--- a/internal/pkg/plugin/reposcaffolding/github/golang/golang.go
+++ b/internal/pkg/plugin/reposcaffolding/github/golang/golang.go
@@ -37,7 +37,7 @@ func InitRepoLocalAndPushToRemote(repoPath string, opts *Options, ghClient *gith
 	var retErr error
 	// It's ok to give the opts.Org to CreateRepo() when create a repository for a authenticated user.
 	if err := ghClient.CreateRepo(opts.Org); err != nil {
-		log.Infof("Failed to create repo: %s.", err)
+		log.Errorf("Failed to create repo: %s.", err)
 		return err
 	}
 	log.Infof("The repo %s has been created.", opts.Repo)

--- a/internal/pkg/pluginengine/change.go
+++ b/internal/pkg/pluginengine/change.go
@@ -92,7 +92,7 @@ func execute(smgr statemanager.Manager, changes []*Change) map[string]error {
 		var err error
 		var returnValue map[string]interface{}
 
-		log.Debugf("Tool's raw changes are: %s.", c.Tool.Options)
+		log.Debugf("Tool's raw changes are: %v.", c.Tool.Options)
 
 		errs := HandleOutputsReferences(smgr, c.Tool.Options)
 		if len(errs) != 0 {

--- a/pkg/util/github/repo.go
+++ b/pkg/util/github/repo.go
@@ -15,7 +15,7 @@ func (c *Client) CreateRepo(org string) error {
 	}
 
 	if org != "" {
-		log.Infof("Prepare to create an organization repository: %s", org)
+		log.Infof("Prepare to create an organization repository: %s/%s", org, repo.GetName())
 	}
 	_, _, err := c.Repositories.Create(c.Context, org, repo)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

**Scope: The GITHUB_TOKEN is scoped to the repository running the workflow. It cannot be used to make changes to any other repositories.**

---

The error we saw:

![image](https://user-images.githubusercontent.com/18692628/163317818-4092b816-461d-4782-9b66-0dcc6e47d8fe.png)

The permission we used:

![image](https://user-images.githubusercontent.com/18692628/163317874-b4bfce50-23f8-4efc-99d9-5cae65644fcc.png)
