### PR TITLE
fix: fix a typo in state.go

### DIFF
--- a/internal/pkg/statemanager/state.go
+++ b/internal/pkg/statemanager/state.go
@@ -86,6 +86,6 @@ func StateKeyGenerateFunc(t *configloader.Tool) StateKey {
 	return StateKey(fmt.Sprintf("%s_%s", t.Name, t.InstanceID))
 }
 
-func GenerateStateKeyByToolNameAndPluginKind(toolName string, instalceID string) StateKey {
-	return StateKey(fmt.Sprintf("%s_%s", toolName, instalceID))
+func GenerateStateKeyByToolNameAndPluginKind(toolName string, instanceID string) StateKey {
+	return StateKey(fmt.Sprintf("%s_%s", toolName, instanceID))
 }


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a PR!

We appreciate you spending the time to work on these changes.

Please fill out as many sections below as possible.
-->

## Key Points

- [ ] This is a breaking change.
- [ ] Documentation (new or existing) is updated.

## Description

Fixed a typo in internal/pkg/statemanager/state.go