### PR TITLE
fix: check new plugin name existence for `create-plugin`

### DIFF
--- a/cmd/devstream/list/list.go
+++ b/cmd/devstream/list/list.go
@@ -21,3 +21,23 @@ func List() {
 		fmt.Println(pluginName)
 	}
 }
+
+// Get plugins name in slice
+func PluginsNameSlice() []string {
+	listPluginsName := strings.Fields(PluginsName)
+	sort.Strings(listPluginsName)
+	return listPluginsName
+}
+
+// Get plugins name in map
+func PluginNamesMap() map[string]struct{} {
+	mp := make(map[string]struct{})
+
+	listPluginsName := strings.Fields(PluginsName)
+
+	for _, pluginName := range listPluginsName {
+		mp[pluginName] = struct{}{}
+	}
+
+	return mp
+}

--- a/internal/pkg/develop/plugin/create.go
+++ b/internal/pkg/develop/plugin/create.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/devstream-io/devstream/cmd/devstream/list"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
@@ -16,6 +17,11 @@ func Create() error {
 	name := viper.GetString("name")
 	if name == "" {
 		return fmt.Errorf("the name must be not \"\", you can specify it by --name flag")
+	}
+	log.Debugf("Got the name: %s.", name)
+
+	if pluginExists(name) {
+		return fmt.Errorf("Plugin name: %s is already exists", name)
 	}
 	log.Debugf("Got the name: %s.", name)
 
@@ -39,4 +45,15 @@ func Create() error {
 	p.PrintHelpInfo()
 
 	return nil
+}
+
+// Check whether the new name exists.
+func pluginExists(name string) bool {
+	pluginMp := list.PluginNamesMap()
+
+	if _, ok := (pluginMp)[name]; ok {
+		return true
+	}
+
+	return false
 }

--- a/internal/pkg/develop/plugin/validate.go
+++ b/internal/pkg/develop/plugin/validate.go
@@ -2,8 +2,6 @@ package plugin
 
 import (
 	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/spf13/viper"
 
@@ -31,8 +29,7 @@ func Validate() error {
 // Validate all plugins
 // calling ValidatePlugin() via all plugins name
 func ValidatePlugins() error {
-	listPluginsName := strings.Fields(list.PluginsName)
-	sort.Strings(listPluginsName)
+	listPluginsName := list.PluginsNameSlice()
 
 	for _, pluginName := range listPluginsName {
 		log.Infof("===== start validating <%s> =====", pluginName)


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a PR!

We appreciate you spending the time to work on these changes.

Please fill out as many sections below as possible.
-->

## Key Points

- [ ] This is a breaking change.
- [ ] Documentation (new or existing) is updated.

## Description

Add function `pluginExists` to check whether new plugin name is used.


### Screenshots

<img width="770" alt="image" src="https://user-images.githubusercontent.com/60642406/167438207-930e2ab8-f45b-4f2b-a2fa-106e6211c391.png">

### Other Information

Any other information that is important to this PR.
