### PR TITLE
refactor: change ways to validate args

### DIFF
--- a/cmd/devstream/develop.go
+++ b/cmd/devstream/develop.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/devstream-io/devstream/cmd/devstream/validator"
 
 	"github.com/spf13/cobra"
 
@@ -21,14 +22,10 @@ var developCMD = &cobra.Command{
 Examples:
   dtm develop create-plugin --name=YOUR-PLUGIN-NAME,
   dtm develop validate-plugin --name=YOUR-PLUGIN-NAME`,
-	Run: developCMDFunc,
+	Run: validator.WithValidators(developCMDFunc, validator.ArgsCountEqual(1), validateDevelopArgs),
 }
 
 func developCMDFunc(cmd *cobra.Command, args []string) {
-	if err := validateDevelopArgs(args); err != nil {
-		log.Fatal(err)
-	}
-
 	developAction := develop.Action(args[0])
 	log.Debugf("The develop action is: %s.", developAction)
 	if err := develop.ExecuteAction(developAction); err != nil {
@@ -38,9 +35,6 @@ func developCMDFunc(cmd *cobra.Command, args []string) {
 
 func validateDevelopArgs(args []string) error {
 	// "create-plugin" or "validate-plugin". Maybe it will be "delete-plugin"/"rename-plugin" in future.
-	if len(args) != 1 {
-		return fmt.Errorf("illegal args count (expect 1, got %d)", len(args))
-	}
 	developAction := develop.Action(args[0])
 	if !develop.IsValideAction(developAction) {
 		return fmt.Errorf("invalide Develop Action")

--- a/cmd/devstream/develop.go
+++ b/cmd/devstream/develop.go
@@ -2,8 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/devstream-io/devstream/cmd/devstream/validator"
-
+	"github.com/devstream-io/devstream/cmd/devstream/options"
 	"github.com/spf13/cobra"
 
 	"github.com/devstream-io/devstream/internal/pkg/develop"
@@ -22,7 +21,7 @@ var developCMD = &cobra.Command{
 Examples:
   dtm develop create-plugin --name=YOUR-PLUGIN-NAME,
   dtm develop validate-plugin --name=YOUR-PLUGIN-NAME`,
-	Run: validator.WithValidators(developCMDFunc, validator.ArgsCountEqual(1), validateDevelopArgs),
+	Run: options.WithValidators(developCMDFunc, options.ArgsCountEqual(1), validateDevelopArgs),
 }
 
 func developCMDFunc(cmd *cobra.Command, args []string) {

--- a/cmd/devstream/list.go
+++ b/cmd/devstream/list.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/devstream-io/devstream/cmd/devstream/validator"
 
 	"github.com/spf13/cobra"
 
@@ -19,7 +20,7 @@ var listCMD = &cobra.Command{
 	Long: `This command lists all of the plugins.
 Examples:
   dtm list plugins`,
-	Run: listCMDFunc,
+	Run: validator.WithValidators(listCMDFunc, validator.ArgsCountEqual(1), validateListCMDArgs),
 }
 
 func listCMDFunc(cmd *cobra.Command, args []string) {
@@ -32,9 +33,6 @@ func listCMDFunc(cmd *cobra.Command, args []string) {
 
 func validateListCMDArgs(args []string) error {
 	// only support "plugins" now
-	if len(args) != 1 {
-		return fmt.Errorf("got illegal args count (expect 1, got %d)", len(args))
-	}
 
 	if args[0] != "plugins" {
 		return fmt.Errorf("arg should be \"plugins\" only")

--- a/cmd/devstream/list.go
+++ b/cmd/devstream/list.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/devstream-io/devstream/cmd/devstream/validator"
-
+	"github.com/devstream-io/devstream/cmd/devstream/options"
 	"github.com/spf13/cobra"
 
 	"github.com/devstream-io/devstream/cmd/devstream/list"
-	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
 var (
@@ -20,14 +18,10 @@ var listCMD = &cobra.Command{
 	Long: `This command lists all of the plugins.
 Examples:
   dtm list plugins`,
-	Run: validator.WithValidators(listCMDFunc, validator.ArgsCountEqual(1), validateListCMDArgs),
+	Run: options.WithValidators(listCMDFunc, options.ArgsCountEqual(1), validateListCMDArgs),
 }
 
 func listCMDFunc(cmd *cobra.Command, args []string) {
-	if err := validateListCMDArgs(args); err != nil {
-		log.Fatal(err)
-	}
-
 	list.List(pluginFilter)
 }
 

--- a/cmd/devstream/options/validator.go
+++ b/cmd/devstream/options/validator.go
@@ -1,4 +1,4 @@
-package validator
+package options
 
 import (
 	"fmt"

--- a/cmd/devstream/show.go
+++ b/cmd/devstream/show.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/devstream-io/devstream/cmd/devstream/validator"
 
 	"github.com/spf13/cobra"
 
@@ -20,14 +21,10 @@ Examples:
   dtm show config --plugin=A-PLUGIN-NAME
   dtm show status --plugin=A-PLUGIN-NAME --name=A-PLUGIN-INSTANCE-NAME
   dtm show status -p=A-PLUGIN-NAME -n=A-PLUGIN-INSTANCE-NAME`,
-	Run: showCMDFunc,
+	Run: validator.WithValidators(showCMDFunc, validator.ArgsCountEqual(1), validateShowArgs),
 }
 
 func showCMDFunc(cmd *cobra.Command, args []string) {
-	if err := validateShowArgs(args); err != nil {
-		log.Fatal(err)
-	}
-
 	showInfo := show.Info(args[0])
 	log.Debugf("The show info is: %s.", showInfo)
 	if err := show.GenerateInfo(showInfo); err != nil {
@@ -37,9 +34,6 @@ func showCMDFunc(cmd *cobra.Command, args []string) {
 
 func validateShowArgs(args []string) error {
 	// arg is "config" or "status" here, maybe will have "output" in the future.
-	if len(args) != 1 {
-		return fmt.Errorf("got illegal args count (expect 1, got %d)", len(args))
-	}
 	showInfo := show.Info(args[0])
 	if !show.IsValideInfo(showInfo) {
 		return fmt.Errorf("invalide Show Info")

--- a/cmd/devstream/show.go
+++ b/cmd/devstream/show.go
@@ -2,8 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/devstream-io/devstream/cmd/devstream/validator"
-
+	"github.com/devstream-io/devstream/cmd/devstream/options"
 	"github.com/spf13/cobra"
 
 	"github.com/devstream-io/devstream/internal/pkg/show"
@@ -21,7 +20,7 @@ Examples:
   dtm show config --plugin=A-PLUGIN-NAME
   dtm show status --plugin=A-PLUGIN-NAME --name=A-PLUGIN-INSTANCE-NAME
   dtm show status -p=A-PLUGIN-NAME -n=A-PLUGIN-INSTANCE-NAME`,
-	Run: validator.WithValidators(showCMDFunc, validator.ArgsCountEqual(1), validateShowArgs),
+	Run: options.WithValidators(showCMDFunc, options.ArgsCountEqual(1), validateShowArgs),
 }
 
 func showCMDFunc(cmd *cobra.Command, args []string) {

--- a/cmd/devstream/validator/validator.go
+++ b/cmd/devstream/validator/validator.go
@@ -1,0 +1,33 @@
+package validator
+
+import (
+	"fmt"
+	"github.com/devstream-io/devstream/pkg/util/log"
+
+	"github.com/spf13/cobra"
+)
+
+// to pre validate args of commands
+
+// WithValidators returns a cobra RunFunc with the given validators
+func WithValidators(runFunc func(cmd *cobra.Command, args []string), validators ...func(args []string) error) func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		for _, validator := range validators {
+			if err := validator(args); err != nil {
+				log.Fatal(err)
+			}
+		}
+		runFunc(cmd, args)
+	}
+
+}
+
+// ArgsCountEqual returns a validator which check the count of args
+func ArgsCountEqual(count int) func(args []string) error {
+	return func(args []string) error {
+		if len(args) != count {
+			return fmt.Errorf("illegal args count (expect %d, got %d)", count, len(args))
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a PR!

We appreciate you spending the time to work on these changes.

Please fill out as many sections below as possible.
-->

## Key Points

- [ ] This is a breaking change.
- [ ] Documentation (new or existing) is updated.

## Description

1. separate args validators and important business code.
2. reduce duplicate code of validators.

### Related Issues
#478 

### Other Information

Maybe the place and name of pkg should be changed.
