### PR TITLE
fix: golang-lint timeout error

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.29
-          args: --timeout 3m0s
+          args: --timeout 5m0s
   build-and-test:
     needs: [golang-lint]
     strategy:


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

# Summary

fix: golang-lint timeout error

![image](https://user-images.githubusercontent.com/18692628/168192548-1465cb5a-1b2b-4a88-8925-04835c37e095.png)
