### PR TITLE
fix: workflow needs write permission

### DIFF
--- a/internal/pkg/plugin/githubactions/golang/templates.go
+++ b/internal/pkg/plugin/githubactions/golang/templates.go
@@ -4,6 +4,7 @@ var prPipeline = `name: Pull Requests Builder
 on:
   pull_request:
     branches: [ master, main ]
+permissions: write-all
 jobs:
   [[- if .Build.Enable]]
   build:
@@ -82,6 +83,7 @@ var mainPipeline = `name: Main Branch Builder
 on:
   push:
     branches: [ master, main ]
+permissions: write-all
 jobs:
   [[- if .Build.Enable]]
   build:


### PR DESCRIPTION
# Summary

github actions workflows need 'write permission', but the repo default config is 'read'.
So we need set it in the workflow to get the permission  while pipelines run


### Current Behavior

![middle_img_v2_ac15d6a6-60cc-4814-8a4d-6b3c8d87b38g](https://user-images.githubusercontent.com/94163234/168236421-4757d9f8-b4cc-4255-bf1e-b7ae5d6e0683.png)

### New Behavior

![image](https://user-images.githubusercontent.com/94163234/168236637-c3ba8cad-20ab-4409-9688-18384c4af9fb.png)
