### PR TITLE
📖`Docs`: update code references in core-concetps

### DIFF
--- a/docs/core-concepts/core-concepts.md
+++ b/docs/core-concepts/core-concepts.md
@@ -4,16 +4,16 @@ The architecture documentation explains how in general DevStream works. If you h
 
 ## 1 Tool
 
-- One of the major part of the _Config_ is a list of tools, defined in [here](https://github.com/devstream-io/devstream/blob/main/internal/pkg/configloader/config.go#L19).
-- Each _Tool_ has its Name, Plugin, and Options, as defined [here](https://github.com/devstream-io/devstream/blob/main/internal/pkg/configloader/config.go#L24).
+- One of the major part of the _Config_ is a list of tools, defined in [here](https://github.com/devstream-io/devstream/blob/main/internal/pkg/configloader/config.go#L23).
+- Each _Tool_ has its Name, Plugin, and Options, as defined [here](https://github.com/devstream-io/devstream/blob/main/internal/pkg/configloader/config.go#L40).
 - Each _Tool_ can have its dependencies, which are specified by the `dependsOn` keyword.
 
-The dependency `dependsOn` is an array of strings, with each element being a dependency. Each dependency is named in the format of "NAME.PLUGIN". See [here](https://github.com/devstream-io/devstream/blob/main/examples/quickstart.yaml#L16) for example.
+The dependency `dependsOn` is an array of strings, with each element being a dependency. Each dependency is named in the format of "NAME.PLUGIN". See [here](https://github.com/devstream-io/devstream/blob/main/examples/tools-quickstart.yaml#L12) for example.
 
 ## 2 State
 
-- The _State_ is actually a map of states, as defined [here](https://github.com/devstream-io/devstream/blob/main/internal/pkg/statemanager/state.go#L21).
-- Each state in the map is a struct containing Name, Plugin, Options, and Resource, as defined [here](https://github.com/devstream-io/devstream/blob/main/internal/pkg/statemanager/state.go#L14).
+- The _State_ is actually a map of states, as defined [here](https://github.com/devstream-io/devstream/blob/main/internal/pkg/statemanager/state.go#L24).
+- Each state in the map is a struct containing Name, Plugin, Options, and Resource, as defined [here](https://github.com/devstream-io/devstream/blob/main/internal/pkg/statemanager/state.go#L16).
 
 ## 3 Resource
 


### PR DESCRIPTION
## Description
update code references in core-concetps

## ScreenShots

> One of the major part of the Config is a list of tools, defined in here
![image](https://user-images.githubusercontent.com/36830265/168775645-bd3f2904-8742-4991-8452-c558915ce6b8.png)

> Each Tool has its Name, Plugin, and Options, as defined here
![image](https://user-images.githubusercontent.com/36830265/168775683-603e1b8c-5123-4aaa-9f42-38853e075e6b.png)

> The dependency dependsOn is an array of strings, with each element being a dependency. Each dependency is named in the format of "NAME.PLUGIN".
![image](https://user-images.githubusercontent.com/36830265/168775716-aa8ed922-ff40-4174-a7d9-4ac1f8c28979.png)

> The State is actually a map of states, as defined here.
![image](https://user-images.githubusercontent.com/36830265/168775745-00e6fad5-f528-4469-8606-b21dc0b1091c.png)

> Each state in the map is a struct containing Name, Plugin, Options, and Resource, as defined here.
![image](https://user-images.githubusercontent.com/36830265/168775768-e1ebf51c-d556-47df-b1a6-f5439723288c.png)
