### PR TITLE
refactor: modify args to subcommand in dtm develop

### DIFF
--- a/cmd/devstream/develop.go
+++ b/cmd/devstream/develop.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-
-	"github.com/devstream-io/devstream/cmd/devstream/options"
 
 	"github.com/devstream-io/devstream/internal/pkg/develop"
 	"github.com/devstream-io/devstream/pkg/util/log"
@@ -19,31 +15,44 @@ var (
 var developCMD = &cobra.Command{
 	Use:   "develop",
 	Short: "Develop is used for develop a new plugin",
-	Long: `Develop is used for develop a new plugin.
-Examples:
-  dtm develop create-plugin --name=YOUR-PLUGIN-NAME,
-  dtm develop validate-plugin --name=YOUR-PLUGIN-NAME`,
-	Run: options.WithValidators(developCMDFunc, options.ArgsCountEqual(1), validateDevelopArgs),
 }
 
-func developCMDFunc(cmd *cobra.Command, args []string) {
-	developAction := develop.Action(args[0])
-	log.Debugf("The develop action is: %s.", developAction)
-	if err := develop.ExecuteAction(developAction); err != nil {
+var developCreatePluginCMD = &cobra.Command{
+	Use:   "create-plugin",
+	Short: "Create a new plugin",
+	Long: `Create-plugin is used for creating a new plugin.
+Exampls:
+	dtm develop create-plugin --name=YOUR-PLUGIN-NAME`,
+	Run: developCreateCMDFunc,
+}
+
+var developValidatePluginCMD = &cobra.Command{
+	Use:   "validate-plugin",
+	Short: "Validate a plugin",
+	Long: `Validate-plugin is used for validating an existing plugin or all plugins.
+Examples:
+	dtm develop validate-plugin --name=YOUR-PLUGIN-NAME,
+	dtm develop validate-plugin --all`,
+	Run: developValidateCMDFunc,
+}
+
+func developCreateCMDFunc(cmd *cobra.Command, args []string) {
+	if err := develop.CreatePlugin(); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func validateDevelopArgs(args []string) error {
-	// "create-plugin" or "validate-plugin". Maybe it will be "delete-plugin"/"rename-plugin" in future.
-	developAction := develop.Action(args[0])
-	if !develop.IsValideAction(developAction) {
-		return fmt.Errorf("invalide Develop Action")
+func developValidateCMDFunc(cmd *cobra.Command, args []string) {
+	if err := develop.ValidatePlugin(); err != nil {
+		log.Fatal(err)
 	}
-	return nil
 }
 
 func init() {
-	developCMD.PersistentFlags().StringVarP(&name, "name", "n", "", "specify name with the new plugin")
-	developCMD.PersistentFlags().BoolVarP(&all, "all", "a", false, "validate all plugins")
+	developCMD.AddCommand(developCreatePluginCMD)
+	developCMD.AddCommand(developValidatePluginCMD)
+
+	developCreatePluginCMD.PersistentFlags().StringVarP(&name, "name", "n", "", "specify name with the new plugin")
+	developValidatePluginCMD.PersistentFlags().StringVarP(&name, "name", "n", "", "specify name with the new plugin")
+	developValidatePluginCMD.PersistentFlags().BoolVarP(&all, "all", "a", false, "validate all plugins")
 }

--- a/cmd/devstream/main.go
+++ b/cmd/devstream/main.go
@@ -78,7 +78,10 @@ func initConfig() {
 	if err := viper.BindPFlags(rootCMD.Flags()); err != nil {
 		log.Fatal(err)
 	}
-	if err := viper.BindPFlags(developCMD.Flags()); err != nil {
+	if err := viper.BindPFlags(developCreatePluginCMD.Flags()); err != nil {
+		log.Fatal(err)
+	}
+	if err := viper.BindPFlags(developValidatePluginCMD.Flags()); err != nil {
 		log.Fatal(err)
 	}
 	if err := viper.BindPFlags(showCMD.Flags()); err != nil {

--- a/internal/pkg/develop/develop.go
+++ b/internal/pkg/develop/develop.go
@@ -22,15 +22,12 @@ func IsValideAction(action Action) bool {
 	return ok
 }
 
-func ExecuteAction(action Action) error {
-	switch action {
-	case ActionCreatePlugin:
-		log.Debugf("Action: %s.", ActionCreatePlugin)
-		return plugin.Create()
-	case ActionValidatePlugin:
-		log.Debugf("Action: %s.", ActionValidatePlugin)
-		return plugin.Validate()
-	default:
-		panic("This should be never happen!")
-	}
+func CreatePlugin() error {
+	log.Debugf("Start create plugin")
+	return plugin.Create()
+}
+
+func ValidatePlugin() error {
+	log.Debugf("Start validate plugin")
+	return plugin.Validate()
 }


### PR DESCRIPTION
## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [ ] I have read through the [CONTRIBUTING.md](../CONTRIBUTING.md) documentation.
- [ ] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description

Modify `create-plugin` and `validate-plugin` from `developAction`(arguments) to subcommand.


## Related Issues

#493 


## New Behavior (screenshots if needed)

- `dtm develop`
![image](https://user-images.githubusercontent.com/60642406/169004195-7c203655-3ee4-4830-abe2-18802e00eb09.png)

- `dtm develop create-plugin`
![image](https://user-images.githubusercontent.com/60642406/169004221-fbd1f131-a58f-4cd6-bf2d-dfe5199406e2.png)

- `dtm develop validate-plugin`
![image](https://user-images.githubusercontent.com/60642406/169004223-18f85138-1194-4a25-bb49-ef7d5d0b09a0.png)