### PR TITLE
feat(pluginmanager): a common plugin traverser && parallel download plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/xanzy/go-gitlab v0.55.1
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/gookit/color.v1 v1.1.6
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	helm.sh/helm/v3 v3.7.2
@@ -182,7 +183,6 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/exp v0.0.0-20210901193431-a062eea981d2 // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20211113001501-0c823b97ae02 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/internal/pkg/configloader/config.go
+++ b/internal/pkg/configloader/config.go
@@ -72,6 +72,21 @@ func (t *Tool) DeepCopy() *Tool {
 	return &retTool
 }
 
+func (t *Tool) Key() string {
+	return fmt.Sprintf("%s.%s", t.Name, t.InstanceID)
+}
+
+func (t *Tool) TrimmedDependsOn() []string {
+	var depends []string
+	for _, d := range t.DependsOn {
+		d = strings.TrimSpace(d)
+		if d != "" {
+			depends = append(depends, d)
+		}
+	}
+	return depends
+}
+
 // LoadConf reads an input file as a general config.
 func LoadConf(configFileName string) (*Config, error) {
 	configFileBytes, err := ioutil.ReadFile(configFileName)

--- a/internal/pkg/configloader/validation.go
+++ b/internal/pkg/configloader/validation.go
@@ -2,7 +2,6 @@ package configloader
 
 import (
 	"fmt"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 
@@ -50,24 +49,12 @@ func validateDependency(tools []Tool) []error {
 	toolMap := make(map[string]bool)
 	// creating the set
 	for _, tool := range tools {
-		key := fmt.Sprintf("%s.%s", tool.Name, tool.InstanceID)
-		toolMap[key] = true
+		toolMap[tool.Key()] = true
 	}
 
 	for _, tool := range tools {
-		// no dependency, pass
-		if len(tool.DependsOn) == 0 {
-			continue
-		}
-
 		// for each dependency
-		for _, dependency := range tool.DependsOn {
-			// skip empty string
-			dependency = strings.TrimSpace(dependency)
-			if dependency == "" {
-				continue
-			}
-
+		for _, dependency := range tool.TrimmedDependsOn() {
 			// generate an error if the dependency isn't in the config set,
 			if _, ok := toolMap[dependency]; !ok {
 				errors = append(errors, fmt.Errorf("tool %s's dependency %s doesn't exist in the config", tool.InstanceID, dependency))

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/viper"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/devstream-io/devstream/internal/pkg/configloader"
 	"github.com/devstream-io/devstream/internal/pkg/version"
@@ -28,69 +27,16 @@ func DownloadPlugins(conf *configloader.Config) error {
 	// download all plugins that don't exist locally
 	dc := NewPbDownloadClient()
 
-	// record download status, tool.key -> status
-	downloadMap := make(map[string]string)
+	// new a traverser to download all plugins
+	traverse := NewTraverser(conf.Tools)
 
 	const (
-		unknown = ""
 		fail    = "fail"
 		success = "success"
 	)
 
-	// judge if the download status of all dependencies of given plugin are fail
-	ifDependsFiled := func(tool *configloader.Tool) (failed bool, failedDepend string) {
-		for _, dep := range tool.TrimmedDependsOn() {
-			if downloadMap[dep] == fail {
-				return true, dep
-			}
-		}
-
-		return false, ""
-	}
-
-	// judge if the download status of all dependencies of given plugin are specific
-	ifDependsSpecified := func(tool *configloader.Tool) bool {
-		specific := true
-		for _, dep := range tool.TrimmedDependsOn() {
-			// if map key not set, it will return default string value ""(unknown)
-			if downloadMap[dep] == unknown {
-				specific = false
-				break
-			}
-		}
-		return specific
-	}
-
-	// get tools whose dependencies' download status are all specific (success or fail)
-	getSpecificStatusTools := func() []configloader.Tool {
-		var tools []configloader.Tool
-		for _, tool := range conf.Tools {
-			// skip if the status of status is specified
-			if downloadMap[tool.Key()] == success || downloadMap[tool.Key()] == fail {
-				continue
-			}
-
-			// select all plugins whose dependencies' download status are specific
-			if ifDependsSpecified(&tool) {
-				tools = append(tools, tool)
-			}
-		}
-		for _, t := range tools {
-			log.Debugf("next download plugins patch: %v", t.Key())
-		}
-
-		return tools
-	}
-
 	// download one tool
 	downloadOneTool := func(tool *configloader.Tool) error {
-		// if the download of the dependent plugin fails, the plugin will not be downloaded either
-		if failed, failedDepend := ifDependsFiled(tool); failed {
-			log.Warnf("The download of plugin <%s> was cancelled because the download of the plugin <%s> it depends on failed.", tool.Key(), failedDepend)
-			// plugins that depend on this plugin will also not be downloaded
-			downloadMap[tool.Key()] = fail
-			return nil
-		}
 
 		pluginFileName := configloader.GetPluginFileName(tool)
 		pluginMD5FileName := configloader.GetPluginMD5FileName(tool)
@@ -124,7 +70,7 @@ func DownloadPlugins(conf *configloader.Config) error {
 		// if .so matches with .md5, continue
 		if isMD5Match {
 			log.Infof("Plugin: %s already exists, no need to download.", pluginFileName)
-			downloadMap[tool.Key()] = success
+			traverse.SetStatus(tool, success)
 			return nil
 		}
 		// if existing .so doesn't matches with .md5, re-download
@@ -137,43 +83,32 @@ func DownloadPlugins(conf *configloader.Config) error {
 		if err := pluginAndMD5Matches(pluginDir, pluginFileName, pluginMD5FileName, tool.Name); err != nil {
 			return err
 		}
-		downloadMap[tool.Key()] = success
+		traverse.SetStatus(tool, success)
 		return nil
 	}
 
-	for {
-		// traverse until all tools' download status are specific.
-		// you can think of this as a simplified version of finding all nodes with entry degree 0 of a directed acyclic graph
-		// returning a batch of nodes with 0 entry at a time instead of just one is to support the parallel download feature in the future.
-		tools := getSpecificStatusTools()
-		if len(tools) == 0 {
-			break
-		}
-		log.Debug("start to download next patches")
+	if err := traverse.GoTraverse(func(tool *configloader.Tool) error {
 
-		var eg errgroup.Group
-		for _, tool := range tools {
-			// define a new var to avoid each loop use the same tool
-			tool := tool
-			// download one tool
-			eg.Go(func() error {
-				return downloadOneTool(&tool)
-			})
+		// if the download of the dependent plugin fails, the plugin will not be downloaded either
+		if traverse.IfDependsOnStatusAnyMatch(tool, fail) {
+
+			log.Warnf("The download of plugin <%s> was cancelled because the download of the plugin it depends on failed.", tool.Key())
+			// set the status of the tool to fail because one of its dependencies failed
+			traverse.SetStatus(tool, fail)
+
+			return nil
 		}
-		if err := eg.Wait(); err != nil {
-			return err
-		}
+
+		log.Debug("start to download plugin: ", tool.Key())
+		return downloadOneTool(tool)
+
+	}); err != nil {
+		return err
 	}
 
 	// check if all plugins are traversed
-	traverseCount := 0
-	for _, status := range downloadMap {
-		if status != unknown {
-			traverseCount++
-		}
-	}
-	if traverseCount != len(conf.Tools) {
-		return fmt.Errorf("the download of some plugins failed, please check the log for more details")
+	if !traverse.CheckAllVisited() {
+		return fmt.Errorf("some plugins are not downloaded correctly, please check the log")
 	}
 
 	return nil

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/viper"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/devstream-io/devstream/internal/pkg/configloader"
 	"github.com/devstream-io/devstream/internal/pkg/version"
@@ -27,9 +28,72 @@ func DownloadPlugins(conf *configloader.Config) error {
 	// download all plugins that don't exist locally
 	dc := NewPbDownloadClient()
 
-	for _, tool := range conf.Tools {
-		pluginFileName := configloader.GetPluginFileName(&tool)
-		pluginMD5FileName := configloader.GetPluginMD5FileName(&tool)
+	// record download status, tool.key -> status
+	downloadMap := make(map[string]string)
+
+	const (
+		unknown = ""
+		fail    = "fail"
+		success = "success"
+	)
+
+	// judge if the download status of all dependencies of given plugin are fail
+	ifDependsFiled := func(tool *configloader.Tool) (failed bool, failedDepend string) {
+		for _, dep := range tool.TrimmedDependsOn() {
+			if downloadMap[dep] == fail {
+				return true, dep
+			}
+		}
+
+		return false, ""
+	}
+
+	// judge if the download status of all dependencies of given plugin are specific
+	ifDependsSpecified := func(tool *configloader.Tool) bool {
+		specific := true
+		for _, dep := range tool.TrimmedDependsOn() {
+			// if map key not set, it will return default string value ""(unknown)
+			if downloadMap[dep] == unknown {
+				specific = false
+				break
+			}
+		}
+		return specific
+	}
+
+	// get tools whose dependencies' download status are all specific (success or fail)
+	getSpecificStatusTools := func() []configloader.Tool {
+		var tools []configloader.Tool
+		for _, tool := range conf.Tools {
+			// skip if the status of status is specified
+			if downloadMap[tool.Key()] == success || downloadMap[tool.Key()] == fail {
+				continue
+			}
+
+			// select all plugins whose dependencies' download status are specific
+			if ifDependsSpecified(&tool) {
+				tools = append(tools, tool)
+			}
+		}
+		for _, t := range tools {
+			log.Debugf("next download plugins patch: %v", t.Key())
+		}
+
+		return tools
+	}
+
+	// download one tool
+	downloadOneTool := func(tool *configloader.Tool) error {
+		// if the download of the dependent plugin fails, the plugin will not be downloaded either
+		if failed, failedDepend := ifDependsFiled(tool); failed {
+			log.Warnf("The download of plugin <%s> was cancelled because the download of the plugin <%s> it depends on failed.", tool.Key(), failedDepend)
+			// plugins that depend on this plugin will also not be downloaded
+			downloadMap[tool.Key()] = fail
+			return nil
+		}
+
+		pluginFileName := configloader.GetPluginFileName(tool)
+		pluginMD5FileName := configloader.GetPluginMD5FileName(tool)
 		// plugin does not exist
 		if _, err := os.Stat(filepath.Join(pluginDir, pluginFileName)); err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
@@ -60,7 +124,8 @@ func DownloadPlugins(conf *configloader.Config) error {
 		// if .so matches with .md5, continue
 		if isMD5Match {
 			log.Infof("Plugin: %s already exists, no need to download.", pluginFileName)
-			continue
+			downloadMap[tool.Key()] = success
+			return nil
 		}
 		// if existing .so doesn't matches with .md5, re-download
 		log.Infof("Plugin: %s doesn't match with .md5 and will be downloaded.", pluginFileName)
@@ -72,7 +137,45 @@ func DownloadPlugins(conf *configloader.Config) error {
 		if err := pluginAndMD5Matches(pluginDir, pluginFileName, pluginMD5FileName, tool.Name); err != nil {
 			return err
 		}
+		downloadMap[tool.Key()] = success
+		return nil
 	}
+
+	for {
+		// traverse until all tools' download status are specific.
+		// you can think of this as a simplified version of finding all nodes with entry degree 0 of a directed acyclic graph
+		// returning a batch of nodes with 0 entry at a time instead of just one is to support the parallel download feature in the future.
+		tools := getSpecificStatusTools()
+		if len(tools) == 0 {
+			break
+		}
+		log.Debug("start to download next patches")
+
+		var eg errgroup.Group
+		for _, tool := range tools {
+			// define a new var to avoid each loop use the same tool
+			tool := tool
+			// download one tool
+			eg.Go(func() error {
+				return downloadOneTool(&tool)
+			})
+		}
+		if err := eg.Wait(); err != nil {
+			return err
+		}
+	}
+
+	// check if all plugins are traversed
+	traverseCount := 0
+	for _, status := range downloadMap {
+		if status != unknown {
+			traverseCount++
+		}
+	}
+	if traverseCount != len(conf.Tools) {
+		return fmt.Errorf("the download of some plugins failed, please check the log for more details")
+	}
+
 	return nil
 }
 

--- a/internal/pkg/pluginmanager/traverser.go
+++ b/internal/pkg/pluginmanager/traverser.go
@@ -183,11 +183,8 @@ func (t *traverser) CheckAllVisited() bool {
 			traverseCount++
 		}
 	}
-	if traverseCount != len(t.tools) {
-		return false
-	}
 
-	return true
+	return traverseCount == len(t.tools)
 }
 
 // GetTools returns all the tools set by the traverser

--- a/internal/pkg/pluginmanager/traverser.go
+++ b/internal/pkg/pluginmanager/traverser.go
@@ -1,0 +1,196 @@
+package pluginmanager
+
+import (
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/devstream-io/devstream/internal/pkg/configloader"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+type (
+	status  = string
+	toolKey = string
+
+	// traverser is a plugin manager that traverses the tools in patch by dependency
+	// each patch returns a list of tools whose dependencies are all visited
+	// you can think of this as a simplified version of finding all nodes with entry degree 0 of a directed acyclic graph
+	traverser struct {
+		traverseMap map[toolKey]status
+		tools       []configloader.Tool
+	}
+)
+
+const (
+	unvisited      status = ""
+	defaultVisited status = "visited"
+)
+
+// NewTraverser creates a new traverser which traverses the plugins in patch by dependency
+func NewTraverser(tools []configloader.Tool) *traverser {
+	return &traverser{
+		traverseMap: make(map[toolKey]status),
+		tools:       tools,
+	}
+}
+
+// Traverse traverses the tools in patch by dependency
+// it will terminate the traversal as soon as it encounters an error
+// the status of the tool being traversed can be set at traversal time via SetStatus
+// if the status is not set manually, it will be set to the default status "visited"
+func (t *traverser) Traverse(op func(tool *configloader.Tool) error) error {
+	for {
+
+		// find the next tools patch to visit
+		tools := t.nextPatch()
+		if len(tools) == 0 {
+			break
+		}
+
+		for _, tool := range tools {
+			if err := op(&tool); err != nil {
+				return err
+			}
+
+			// The one who calls this function should set the status of the tool being traversed
+			// if the status is not set manually, it will be set to the default status "visited"
+			if t.traverseMap[tool.Key()] == unvisited {
+				t.traverseMap[tool.Key()] = defaultVisited
+			}
+		}
+	}
+	return nil
+}
+
+// GoTraverse likes Traverse, but it traverses parallel
+func (t *traverser) GoTraverse(op func(tool *configloader.Tool) error) error {
+	for {
+
+		// find the next tools patch to visit
+		tools := t.nextPatch()
+		if len(tools) == 0 {
+			break
+		}
+
+		var eg errgroup.Group
+		for _, tool := range tools {
+			// define a new var to avoid each loop use the same tool
+			tool := tool
+			// set up a goroutine for each tool
+			eg.Go(func() error {
+				if err := op(&tool); err != nil {
+					return err
+				}
+
+				// The one who calls this function should set the status of the tool being traversed
+				// if the status is not set manually, it will be set to the default status "visited"
+				if t.traverseMap[tool.Key()] == unvisited {
+					t.traverseMap[tool.Key()] = defaultVisited
+				}
+				return nil
+			})
+		}
+		// any goroutine encounters an error, the program immediately returns
+		if err := eg.Wait(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// nextPatch returns the next patch of the tools which are not visited and whose dependencies are all visited
+func (t *traverser) nextPatch() []configloader.Tool {
+	var nextPatch []configloader.Tool
+	for _, tool := range t.tools {
+		// skip the tool that has been visited
+		if t.IfToolVisited(&tool) {
+			continue
+		}
+
+		// select all tools whose dependencies are all visited
+		if t.IfDependenciesOfToolAllVisited(&tool) {
+			nextPatch = append(nextPatch, tool)
+		}
+	}
+
+	patchKeys := make([]toolKey, 0, len(nextPatch))
+	for _, tool := range nextPatch {
+		patchKeys = append(patchKeys, tool.Key())
+	}
+	log.Debugf("Next patch: %v", strings.Join(patchKeys, ", "))
+
+	return nextPatch
+
+}
+
+// SetStatus sets the specific traverse status of the tool
+func (t *traverser) SetStatus(tool *configloader.Tool, status status) {
+	t.traverseMap[tool.Key()] = status
+}
+
+// GetStatus gets the specific traverse status of the tool
+func (t *traverser) GetStatus(tool *configloader.Tool) status {
+	return t.traverseMap[tool.Key()]
+}
+
+// IfToolVisited returns true if the tool has been visited
+func (t *traverser) IfToolVisited(tool *configloader.Tool) bool {
+	return t.traverseMap[tool.Key()] != unvisited
+}
+
+// IfDependenciesOfToolAllVisited returns true if all dependencies of the tool have been visited
+func (t *traverser) IfDependenciesOfToolAllVisited(tool *configloader.Tool) bool {
+	for _, dep := range tool.TrimmedDependsOn() {
+		if t.traverseMap[dep] == unvisited {
+			return false
+		}
+	}
+	return true
+}
+
+// IfDependsOnStatusAnyMatch  returns true if any dependencies of the tool match the status
+func (t *traverser) IfDependsOnStatusAnyMatch(tool *configloader.Tool, status status) bool {
+	for _, dep := range tool.TrimmedDependsOn() {
+		if t.traverseMap[dep] == status {
+			return true
+		}
+	}
+	return false
+}
+
+// IfDependsOnStatusAllMatch  returns true if all dependencies of the tool match the status
+func (t *traverser) IfDependsOnStatusAllMatch(tool *configloader.Tool, status status) bool {
+	for _, dep := range tool.TrimmedDependsOn() {
+		if t.traverseMap[dep] != status {
+			return false
+		}
+	}
+	return true
+}
+
+// CheckAllVisited Check if all tools have been visited
+// if Traverse does not return error, this function will return true unless code of traverser is wrong
+func (t *traverser) CheckAllVisited() bool {
+	if len(t.traverseMap) != len(t.tools) {
+		return false
+	}
+
+	traverseCount := 0
+	for _, tool := range t.tools {
+		if t.traverseMap[tool.Key()] != unvisited {
+			traverseCount++
+		}
+	}
+	if traverseCount != len(t.tools) {
+		return false
+	}
+
+	return true
+}
+
+// GetTools returns all the tools set by the traverser
+func (t *traverser) GetTools() []configloader.Tool {
+	return t.tools
+}

--- a/internal/pkg/pluginmanager/traverser_test.go
+++ b/internal/pkg/pluginmanager/traverser_test.go
@@ -1,0 +1,220 @@
+package pluginmanager
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/devstream-io/devstream/internal/pkg/configloader"
+)
+
+func TestTraverserPatches(t *testing.T) {
+	tools := []configloader.Tool{
+		{InstanceID: "a", Name: "a"},
+		{InstanceID: "b", Name: "b"},
+		{InstanceID: "c", Name: "c", DependsOn: []string{"a.a"}},
+		{InstanceID: "d", Name: "d", DependsOn: []string{"b.b", "c.c"}},
+		{InstanceID: "e", Name: "e", DependsOn: []string{"d.d"}},
+		{InstanceID: "f", Name: "f", DependsOn: []string{"a.a"}},
+		{InstanceID: "g", Name: "g"},
+	}
+
+	traverse := NewTraverser(tools)
+	patch := traverse.nextPatch()
+	if !comparePatch(patch, []string{"a.a", "b.b", "g.g"}) {
+		t.Errorf("Expected patch %v, got %v", []string{"a.a", "b.b", "g.g"}, toolsToKeys(patch))
+	}
+	for _, tool := range patch {
+		traverse.SetStatus(&tool, defaultVisited)
+	}
+
+	patch = traverse.nextPatch()
+	if !comparePatch(patch, []string{"c.c", "f.f"}) {
+		t.Errorf("Expected patch %v, got %v", []string{"c.c", "f.f"}, toolsToKeys(patch))
+	}
+	for _, tool := range patch {
+		traverse.SetStatus(&tool, defaultVisited)
+	}
+
+	patch = traverse.nextPatch()
+	if !comparePatch(patch, []string{"d.d"}) {
+		t.Errorf("Expected patch %v, got %v", []string{"d.d"}, toolsToKeys(patch))
+	}
+	for _, tool := range patch {
+		traverse.SetStatus(&tool, defaultVisited)
+	}
+
+	patch = traverse.nextPatch()
+	if !comparePatch(patch, []string{"e.e"}) {
+		t.Errorf("Expected patch %v, got %v", []string{"e.e"}, toolsToKeys(patch))
+	}
+	for _, tool := range patch {
+		traverse.SetStatus(&tool, defaultVisited)
+	}
+
+	patch = traverse.nextPatch()
+	if len(patch) != 0 {
+		t.Errorf("Expected empty patch, got %v", toolsToKeys(patch))
+	}
+}
+
+func TestTraverserWithNoError(t *testing.T) {
+	tools := []configloader.Tool{
+		{InstanceID: "a", Name: "a"},
+		{InstanceID: "b", Name: "b"},
+		{InstanceID: "c", Name: "c", DependsOn: []string{"a.a"}},
+		{InstanceID: "d", Name: "d", DependsOn: []string{"b.b", "c.c"}},
+		{InstanceID: "e", Name: "e", DependsOn: []string{"d.d"}},
+		{InstanceID: "f", Name: "f", DependsOn: []string{"a.a"}},
+		{InstanceID: "g", Name: "g"},
+	}
+	traverse := NewTraverser(tools)
+	traverseList := make([]string, 0)
+	traverseFunc := func(tool *configloader.Tool) error {
+		traverseList = append(traverseList, tool.Key())
+		return nil
+	}
+	err := traverse.Traverse(traverseFunc)
+	assert.NoError(t, err)
+	assert.Equal(t, true, traverse.CheckAllVisited())
+	assert.Equal(t, []string{"a.a", "b.b", "g.g", "c.c", "f.f", "d.d", "e.e"}, traverseList)
+}
+
+func TestTraverserWithError(t *testing.T) {
+	tools := []configloader.Tool{
+		{InstanceID: "a", Name: "a"},
+		{InstanceID: "b", Name: "b"},
+		{InstanceID: "c", Name: "c", DependsOn: []string{"a.a"}},
+		{InstanceID: "d", Name: "d", DependsOn: []string{"b.b", "c.c"}},
+		{InstanceID: "e", Name: "e", DependsOn: []string{"d.d"}},
+		{InstanceID: "f", Name: "f", DependsOn: []string{"a.a"}},
+		{InstanceID: "g", Name: "g"},
+	}
+	traverse := NewTraverser(tools)
+	traverseFunc := func(tool *configloader.Tool) error {
+		if tool.Key() == "c.c" {
+			return errors.New("abort traversal")
+		}
+		return nil
+	}
+	err := traverse.Traverse(traverseFunc)
+
+	// get tools that were visited
+	traverseList := make([]string, 0)
+	for _, tool := range tools {
+		if traverse.IfToolVisited(&tool) {
+			traverseList = append(traverseList, tool.Key())
+		}
+	}
+
+	// because of the error, the traversal should stop at c.c
+	assert.Equal(t, []string{"a.a", "b.b", "g.g"}, traverseList)
+
+	assert.Equal(t, "abort traversal", err.Error())
+}
+
+func TestGoTraverserWithNoError(t *testing.T) {
+	tools := []configloader.Tool{
+		{InstanceID: "a", Name: "a"},
+		{InstanceID: "b", Name: "b"},
+		{InstanceID: "c", Name: "c", DependsOn: []string{"a.a"}},
+		{InstanceID: "d", Name: "d", DependsOn: []string{"b.b", "c.c"}},
+		{InstanceID: "e", Name: "e", DependsOn: []string{"d.d"}},
+		{InstanceID: "f", Name: "f", DependsOn: []string{"a.a"}},
+		{InstanceID: "g", Name: "g"},
+	}
+	traverse := NewTraverser(tools)
+	traverseList := make([]string, 0)
+	traverseFunc := func(tool *configloader.Tool) error {
+		traverseList = append(traverseList, tool.Key())
+		return nil
+	}
+	err := traverse.GoTraverse(traverseFunc)
+	assert.NoError(t, err)
+	assert.True(t, traverse.CheckAllVisited())
+
+	assert.True(t, ifStringSetEqual(traverseList, []string{"a.a", "b.b", "g.g", "c.c", "f.f", "d.d", "e.e"}))
+}
+
+func TestGoTraverserWithError(t *testing.T) {
+	tools := []configloader.Tool{
+		{InstanceID: "a", Name: "a"},
+		{InstanceID: "b", Name: "b"},
+		{InstanceID: "c", Name: "c", DependsOn: []string{"a.a"}},
+		{InstanceID: "d", Name: "d", DependsOn: []string{"b.b", "c.c"}},
+		{InstanceID: "e", Name: "e", DependsOn: []string{"d.d"}},
+		{InstanceID: "f", Name: "f", DependsOn: []string{"a.a"}},
+		{InstanceID: "g", Name: "g"},
+	}
+	traverse := NewTraverser(tools)
+	traverseFunc := func(tool *configloader.Tool) error {
+		if tool.Key() == "c.c" {
+			return errors.New("abort traversal")
+		}
+		return nil
+	}
+	err := traverse.GoTraverse(traverseFunc)
+
+	// get tools that were visited
+	traverseList := make([]string, 0)
+	for _, tool := range tools {
+		if traverse.IfToolVisited(&tool) {
+			traverseList = append(traverseList, tool.Key())
+		}
+	}
+
+	assert.Error(t, err, "abort traversal")
+
+	// because of the error, the traversal should stop at c.c
+	// but because of the goroutine, maybe f.f is visited, they are in same patch
+
+	success := ifStringSetEqual(traverseList, []string{"a.a", "b.b", "g.g"}) ||
+		ifStringSetEqual(traverseList, []string{"a.a", "b.b", "g.g", "f.f"})
+	assert.True(t, success, fmt.Sprintf("actual tarverlist%v", traverseList))
+}
+
+// check if the patch returns is correct
+func comparePatch(patch []configloader.Tool, toolKeys []string) bool {
+	if len(patch) != len(toolKeys) {
+		return false
+	}
+
+	pathKeys := toolsToKeys(patch)
+
+	return ifStringSetEqual(pathKeys, toolKeys)
+}
+
+// compare two string sets if they are equal ignoring the order
+func ifStringSetEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	// sort two slices to compare conveniently
+	sort.Slice(a, func(i, j int) bool {
+		return a[i] < a[j]
+	})
+	sort.Slice(b, func(i, j int) bool {
+		return b[i] < b[j]
+	})
+
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// toolsToKeys returns a slice of tool keys
+func toolsToKeys(tools []configloader.Tool) []string {
+	keys := make([]string, 0)
+	for _, tool := range tools {
+		keys = append(keys, tool.Key())
+	}
+	return keys
+}


### PR DESCRIPTION
## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

## Related Issues
close #579 

## New Behavior (screenshots if needed)

use `gitops.yaml` for example:

Here is the download patches test. (use plguins from `make build`)
![USXG V(S9JET3{_ODWA0JV9](https://user-images.githubusercontent.com/36830265/169686212-83ad789a-d4ae-4152-9861-8077ac6f30e9.png)

Let's change the name of `argocd` to test if download can be terminated automatically.
![2X(C8C V)3FA2)GTC 062$U](https://user-images.githubusercontent.com/36830265/169686308-9950cb2d-34aa-4894-8b11-52d45336aa21.png)


## More Infomation.

1. **This is just a demo. I want to do this with everyone in DevStream**. 
2. Have fun finding bugs and refactoring it.
3. for structure: I dont't think the funcs in `DownloadPlugins` will be reuse. So I made them func vars. Maybe we can turn it into a parallel download class and convert all the function variables to methods of the class. This would be more conducive to testing.
4. It is difficult to test. Because now the dev version of the code is not downloading the plugin from the web but pre-compiling it. Maybe we can write another mock class for plugin downloads that looks the same as downloading a plugin from the web except that it reads the plugin locally.

## Let's use the magic of our community to improve it together, thank you!

