### PR TITLE
A better way to execute commands in Framework.

### DIFF
--- a/docs/development/project-layout.md
+++ b/docs/development/project-layout.md
@@ -39,6 +39,8 @@ It's ok not to use it if your app project is really small and where an extra lev
 
 The `pkg` directory origins: The old Go source code used to use `pkg` for its packages and then various Go projects in the community started copying the pattern (see [`this`](https://twitter.com/bradfitz/status/1039512487538970624) Brad Fitzpatrick's tweet for more context).
 
+But Take care of func which contains `Warning` in Comment.Especially, The `os.ExecInSystem` func, use Safe one instead.
+
 ### `/vendor`
 
 Application dependencies (managed manually or by your favorite dependency management tool like the new built-in [`Go Modules`](https://github.com/golang/go/wiki/Modules) feature). The `go mod vendor` command will create the `/vendor` directory for you. Note that you might need to add the `-mod=vendor` flag to your `go build` command if you are not using Go 1.14 where it's on by default.

--- a/pkg/util/os/exec.go
+++ b/pkg/util/os/exec.go
@@ -12,6 +12,8 @@ import (
 
 // ExecInSystem can exec a command with some params in system.
 // All logs produced by command would be print to stdout and write into logsBuffer if it is not nil
+// Warning: The ExecInSystem func is insecure when provide as pkg/utils in Framework.
+// That will Cause Command injection.
 func ExecInSystem(execPath string, params []string, logsBuffer *bytes.Buffer, print bool) error {
 	paramStr := strings.Join(params, " ")
 	fmt.Printf("Params : %s\n", paramStr)
@@ -20,6 +22,69 @@ func ExecInSystem(execPath string, params []string, logsBuffer *bytes.Buffer, pr
 	cmdName := "sh"
 
 	cmd := exec.Command(cmdName, c, paramStr)
+	cmd.Dir = execPath
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	// print logs
+	var lock sync.Mutex
+	outReader := bufio.NewReader(stdout)
+	errReader := bufio.NewReader(stderr)
+	printLog := func(reader *bufio.Reader, stdType string) {
+		for {
+			line, err := reader.ReadString('\n')
+			if print {
+				fmt.Printf("%s: %s", stdType, line)
+			}
+			if logsBuffer != nil {
+				lock.Lock()
+				logsBuffer.WriteString(line)
+				lock.Unlock()
+			}
+			if err != nil || err == io.EOF {
+				break
+			}
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		printLog(outReader, "Stdout")
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		printLog(errReader, "Stderr")
+	}()
+
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	wg.Wait()
+	return cmd.Wait()
+}
+
+// SafeExecInSystem can exec a command with some params in system.
+// All logs produced by command would be print to stdout and write into logsBuffer if it is not nil
+// Warning: Don't let other people control the commandExe Param
+func SafeExecInSystem(execPath string, cmdName string, params []string, logsBuffer *bytes.Buffer, print bool) error {
+	fmt.Printf("Exec: %s\n", commandExe)
+	fmt.Printf("Params : %s\n", strings.Join(params, " "))
+
+	cmd := exec.Command(cmdName, params...)
 	cmd.Dir = execPath
 
 	stdout, err := cmd.StdoutPipe()

--- a/pkg/util/os/exec.go
+++ b/pkg/util/os/exec.go
@@ -77,9 +77,11 @@ func ExecInSystem(execPath string, shellCommand string, logsBuffer *bytes.Buffer
 
 // SafeExecInSystem can exec a command with some params in system.
 // All logs produced by command would be print to stdout and write into logsBuffer if it is not nil
-// Warning: The SafeExecInSystem func is secure to break the command injection but blocked any strings contains "sh" or "cmd" in params@cmdName to avoid the injection
-// when provide as pkg/utils in Framework.
-// That will Cause Command injection.
+// Warning: The SafeExecInSystem func is not enough secure to defeat the command injection.
+// This Func provide a way to avoid params to pollute the whole command.
+// Warning: you still can use like command `python -c "{python shell}"` to introduce the code injection.
+// even the `kubectl exec` to execute in your k8s.
+// when using this func in Plugin, you should take care of parameters for the cmd has no such dangerous functions.
 func SafeExecInSystem(execPath string, cmdName string, params []string, logsBuffer *bytes.Buffer, print bool) error {
 	fmt.Printf("Exec: %s\n", cmdName)
 	fmt.Printf("Params : %s\n", strings.Join(params, " "))

--- a/pkg/util/os/exec.go
+++ b/pkg/util/os/exec.go
@@ -81,7 +81,7 @@ func ExecInSystem(execPath string, params []string, logsBuffer *bytes.Buffer, pr
 // All logs produced by command would be print to stdout and write into logsBuffer if it is not nil
 // Warning: Don't let other people control the commandExe Param
 func SafeExecInSystem(execPath string, cmdName string, params []string, logsBuffer *bytes.Buffer, print bool) error {
-	fmt.Printf("Exec: %s\n", commandExe)
+	fmt.Printf("Exec: %s\n", cmdName)
 	fmt.Printf("Params : %s\n", strings.Join(params, " "))
 
 	cmd := exec.Command(cmdName, params...)

--- a/test/Evil_test.go
+++ b/test/Evil_test.go
@@ -2,17 +2,29 @@ package test
 
 import (
 	"bytes"
-	"github.com/devstream-io/devstream/pkg/util/os"
 	"testing"
+
+	"github.com/devstream-io/devstream/pkg/util/os"
 )
 
 func TestExecInSystem(t *testing.T) {
-	paramsYouThink := []string{
-		"whoami",
-		"",
-		";echo YOU GOT HACKED;",
-	}
 	log := bytes.NewBuffer([]byte{})
-	os.ExecInSystem(".", paramsYouThink, log, true)
-	os.SafeExecInSystem(".", "whoami", paramsYouThink, log, true)
+	paramsYouThink := "echo This Normal"
+	paramsYouThink = paramsYouThink + ";cat /etc/passwd;echo This is accident."
+	os.ExecInSystem(".", paramsYouThink, log, true) // Unsafe allow injections but allow more.
+	paramsYouThink2 := []string{
+		"-al",
+		".",
+		";cat /etc/passwd;echo This is accident.",
+	}
+	os.SafeExecInSystem(".", "ls", paramsYouThink2, log, true)                           // Blocked
+	os.SafeExecInSystem(".", "echo bad Commands;cat /etc/passwd", []string{}, log, true) // Blocked
+	os.SafeExecInSystem(".", "sh", []string{
+		"-c",
+		";cat /etc/passwd;echo This is accident.",
+	}, log, true) // Blocked
+	params := "--help"
+	os.SafeExecInSystem(".", "kubectl", []string{
+		params,
+	}, log, true) // Success.
 }

--- a/test/Evil_test.go
+++ b/test/Evil_test.go
@@ -1,0 +1,17 @@
+package test
+
+import (
+	"bytes"
+	"github.com/devstream-io/devstream/pkg/util/os"
+	"testing"
+)
+
+func TestExecInSystem(t *testing.T) {
+	paramsYouThink := []string{
+		"whoami",
+		"",
+		";echo YOU GOT HACKED;",
+	}
+	log := bytes.NewBuffer([]byte{})
+	os.ExecInSystem(".", paramsYouThink, log, true)
+}

--- a/test/Evil_test.go
+++ b/test/Evil_test.go
@@ -14,4 +14,5 @@ func TestExecInSystem(t *testing.T) {
 	}
 	log := bytes.NewBuffer([]byte{})
 	os.ExecInSystem(".", paramsYouThink, log, true)
+	os.SafeExecInSystem(".", "whoami", paramsYouThink, log, true)
 }

--- a/test/evil_test.go
+++ b/test/evil_test.go
@@ -20,7 +20,7 @@ func TestExecInSystem(t *testing.T) {
 		".",
 		";cat /etc/passwd;echo This is accident.",
 	}
-	os.SafeExecInSystem(".", "ls", paramsYouThink2, log, true)                           // Blocked
+	os.SafeExecInSystem(".", "ls", paramsYouThink2, log, true) // Blocked
 
 	// inject to cmdName
 	os.SafeExecInSystem(".", "echo bad Commands;cat /etc/passwd", []string{}, log, true) // Blocked
@@ -36,4 +36,10 @@ func TestExecInSystem(t *testing.T) {
 	os.SafeExecInSystem(".", "kubectl", []string{
 		params,
 	}, log, true) // Success.
+
+	os.SafeExecInSystem(".", "python", []string{
+		"-c",
+		"import os;os.system('echo This is accident.')",
+	}, log, true) // Success.
+
 }

--- a/test/evil_test.go
+++ b/test/evil_test.go
@@ -9,21 +9,30 @@ import (
 
 func TestExecInSystem(t *testing.T) {
 	log := bytes.NewBuffer([]byte{})
+	// normal inject
 	paramsYouThink := "echo This Normal"
 	paramsYouThink = paramsYouThink + ";cat /etc/passwd;echo This is accident."
-	os.ExecInSystem(".", paramsYouThink, log, true) // Unsafe allow injections but allow more.
+	os.ExecInSystem(".", paramsYouThink, log, true) // Unsafe allow injections but allow complex commands when hardcode.
+
+	// inject to params
 	paramsYouThink2 := []string{
 		"-al",
 		".",
 		";cat /etc/passwd;echo This is accident.",
 	}
 	os.SafeExecInSystem(".", "ls", paramsYouThink2, log, true)                           // Blocked
+
+	// inject to cmdName
 	os.SafeExecInSystem(".", "echo bad Commands;cat /etc/passwd", []string{}, log, true) // Blocked
+
+	// Try to introduce a shell command
 	os.SafeExecInSystem(".", "sh", []string{
 		"-c",
 		";cat /etc/passwd;echo This is accident.",
 	}, log, true) // Blocked
 	params := "--help"
+
+	// Try to test normal func.
 	os.SafeExecInSystem(".", "kubectl", []string{
 		params,
 	}, log, true) // Success.


### PR DESCRIPTION
## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](../CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
a fix to issue #583
Do some check before executed and provide a fix and add document for it.  

## Related Issues
#583 

## New Behavior (screenshots if needed)
```
=== RUN   TestExecInSystem
Shell Command: echo This Normal;cat /etc/passwd;echo This is accident.
Stdout: This Normal
Stdout: root:x:0:0:root:/root:/bin/zsh
Stdout: daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
....
Stderr: Stdout: This is accident.
Stdout: Exec: ls
Params : -al . ;cat /etc/passwd;echo This is accident.
Stderr: ls: 无法访问 ';cat /etc/passwd;echo This is accident.': 没有那个文件或目录
Stdout: .:
Stdout: 总用量 16
Stdout: drwxr-xr-x  3 kali kali 4096 May 23 12:19 .
Stdout: drwxr-xr-x 13 kali kali 4096 May 23 12:09 ..
Stdout: drwxr-xr-x  3 kali kali 4096 May 22 22:30 e2e
Stdout: -rw-r--r--  1 kali kali 1047 May 23 12:19 evil_test.go
Stdout: Stderr: Exec: echo bad Commands;cat /etc/passwd
Params : 
Stdout: Exec: sh
Params : -c ;cat /etc/passwd;echo This is accident.
Exec: kubectl
Params : --help
Stderr: Stdout: kubectl controls the Kubernetes cluster manager.
Stdout: 
Stdout:  Find more information at: https://kubernetes.io/docs/reference/kubectl/overview/
Stdout: 
Stdout: Basic Commands (Beginner):
Stdout:   create        Create a resource from a file or from stdin.
Stdout:   expose        Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service
Stdout:   run           Run a particular image on the cluster
Stdout:   set           Set specific features on objects
Stdout: 
Stdout: Basic Commands (Intermediate):
Stdout:   explain       Documentation of resources
Stdout:   get           Display one or many resources
Stdout:   edit          Edit a resource on the server
Stdout:   delete        Delete resources by filenames, stdin, resources and names, or by resources and label selector
Stdout: 
Stdout: Deploy Commands:
Stdout:   rollout       Manage the rollout of a resource
Stdout:   scale         Set a new size for a Deployment, ReplicaSet or Replication Controller
Stdout:   autoscale     Auto-scale a Deployment, ReplicaSet, or ReplicationController
Stdout: 
Stdout: Cluster Management Commands:
Stdout:   certificate   Modify certificate resources.
Stdout:   cluster-info  Display cluster info
Stdout:   top           Display Resource (CPU/Memory/Storage) usage.
Stdout:   cordon        Mark node as unschedulable
Stdout:   uncordon      Mark node as schedulable
Stdout:   drain         Drain node in preparation for maintenance
Stdout:   taint         Update the taints on one or more nodes
Stdout: 
Stdout: Troubleshooting and Debugging Commands:
Stdout:   describe      Show details of a specific resource or group of resources
Stdout:   logs          Print the logs for a container in a pod
Stdout:   attach        Attach to a running container
Stdout:   exec          Execute a command in a container
Stdout:   port-forward  Forward one or more local ports to a pod
Stdout:   proxy         Run a proxy to the Kubernetes API server
Stdout:   cp            Copy files and directories to and from containers.
Stdout:   auth          Inspect authorization
Stdout:   debug         Create debugging sessions for troubleshooting workloads and nodes
Stdout: 
Stdout: Advanced Commands:
Stdout:   diff          Diff live version against would-be applied version
Stdout:   apply         Apply a configuration to a resource by filename or stdin
Stdout:   patch         Update field(s) of a resource
Stdout:   replace       Replace a resource by filename or stdin
Stdout:   wait          Experimental: Wait for a specific condition on one or many resources.
Stdout:   kustomize     Build a kustomization target from a directory or a remote url.
Stdout: 
Stdout: Settings Commands:
Stdout:   label         Update the labels on a resource
Stdout:   annotate      Update the annotations on a resource
Stdout:   completion    Output shell completion code for the specified shell (bash or zsh)
Stdout: 
Stdout: Other Commands:
Stdout:   api-resources Print the supported API resources on the server
Stdout:   api-versions  Print the supported API versions on the server, in the form of "group/version"
Stdout:   config        Modify kubeconfig files
Stdout:   plugin        Provides utilities for interacting with plugins.
Stdout:   version       Print the client and server version information
Stdout: 
Stdout: Usage:
Stdout:   kubectl [flags] [options]
Stdout: 
Stdout: Use "kubectl <command> --help" for more information about a given command.
Stdout: Use "kubectl options" for a list of global command-line options (applies to all commands).
Stderr: Stdout: --- PASS: TestExecInSystem (0.09s)
PASS
```