### PR TITLE
test: improve the naming of the directory used for unit testing

### DIFF
--- a/internal/pkg/pluginmanager/downloader_test.go
+++ b/internal/pkg/pluginmanager/downloader_test.go
@@ -12,7 +12,7 @@ func TestDownload(t *testing.T) {
 	os.Remove(filepath.Join(".", "argocdapp_0.0.1-rc1.so"))
 
 	c := NewDownloadClient()
-	err := c.download(".", "argocdapp_0.0.1-rc1.so", "0.0.1-rc1")
+	err := c.download(".", "argocdapp_0.0.1-rc1.so", "0.0.1-ut-do-not-delete")
 	if err != nil {
 		t.Fatal("downloaded error")
 	}
@@ -22,7 +22,7 @@ func TestDownload(t *testing.T) {
 
 func TestDownloadNotFound(t *testing.T) {
 	c := NewDownloadClient()
-	err := c.download(".", "doesntexist", "0.0.1")
+	err := c.download(".", "doesntexist", "0.0.1-ut-do-not-delete")
 	// Since the right granted to public users on aws does not include listing bucket
 	// AWS returns 403 instead of 404 when acquiring an object where bucket does not exist: there is no list right.
 	assert.Contains(t, err.Error(), "403")


### PR DESCRIPTION
Signed-off-by: KeHao <hao.ke@merico.dev>

# Summary

Improve the naming of the directory used for unit testing.

## Description

Improve the naming of the directory used for unit testing, while retaining the original unit testing directory of s3, so as not to affect users who have not updated their codes in the future.

## New Behavior (screenshots if needed)

![image](https://user-images.githubusercontent.com/103085894/169795026-0433bd1e-81fb-4fbc-958e-af8a7680fe2d.png)

