### PR TITLE
fix: some commands do not need the -f parameter #559

### DIFF
--- a/cmd/devstream/apply.go
+++ b/cmd/devstream/apply.go
@@ -25,3 +25,6 @@ func applyCMDFunc(cmd *cobra.Command, args []string) {
 	}
 	log.Success("Apply finished.")
 }
+func init() {
+	applyCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
+}

--- a/cmd/devstream/apply.go
+++ b/cmd/devstream/apply.go
@@ -27,4 +27,6 @@ func applyCMDFunc(cmd *cobra.Command, args []string) {
 }
 func init() {
 	applyCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
+	applyCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir, "plugins directory")
+	applyCMD.Flags().BoolVarP(&continueDirectly, "yes", "y", false, "apply directly without confirmation")
 }

--- a/cmd/devstream/common.go
+++ b/cmd/devstream/common.go
@@ -1,0 +1,7 @@
+package main
+
+var (
+	configFile       string
+	pluginDir        string
+	continueDirectly bool
+)

--- a/cmd/devstream/delete.go
+++ b/cmd/devstream/delete.go
@@ -29,4 +29,5 @@ func deleteCMDFunc(cmd *cobra.Command, args []string) {
 
 func init() {
 	deleteCMD.PersistentFlags().BoolVarP(&isForceDelete, "force", "", false, "force delete by config")
+	deleteCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
 }

--- a/cmd/devstream/delete.go
+++ b/cmd/devstream/delete.go
@@ -9,6 +9,8 @@ import (
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
+var isForceDelete bool
+
 var deleteCMD = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete DevOps tools according to DevStream configuration file",
@@ -28,6 +30,8 @@ func deleteCMDFunc(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	deleteCMD.PersistentFlags().BoolVarP(&isForceDelete, "force", "", false, "force delete by config")
+	deleteCMD.Flags().BoolVarP(&isForceDelete, "force", "", false, "force delete by config")
 	deleteCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
+	deleteCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir, "plugins directory")
+	deleteCMD.Flags().BoolVarP(&continueDirectly, "yes", "y", false, "delete directly without confirmation")
 }

--- a/cmd/devstream/destroy.go
+++ b/cmd/devstream/destroy.go
@@ -27,4 +27,5 @@ func destroyCMDFunc(cmd *cobra.Command, args []string) {
 
 func init() {
 	destroyCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
+	destroyCMD.Flags().BoolVarP(&continueDirectly, "yes", "y", false, "destroy directly without confirmation")
 }

--- a/cmd/devstream/destroy.go
+++ b/cmd/devstream/destroy.go
@@ -24,3 +24,7 @@ func destroyCMDFunc(cmd *cobra.Command, args []string) {
 	}
 	log.Success("Destroy finished.")
 }
+
+func init() {
+	destroyCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
+}

--- a/cmd/devstream/init.go
+++ b/cmd/devstream/init.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/devstream-io/devstream/internal/pkg/configloader"
+	"github.com/devstream-io/devstream/internal/pkg/pluginengine"
 	"github.com/devstream-io/devstream/internal/pkg/pluginmanager"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
@@ -29,4 +30,9 @@ func initCMDFunc(cmd *cobra.Command, args []string) {
 	}
 
 	log.Success("Initialize finished.")
+}
+
+func init() {
+	initCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
+	initCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir, "plugins directory")
 }

--- a/cmd/devstream/main.go
+++ b/cmd/devstream/main.go
@@ -11,12 +11,7 @@ import (
 )
 
 var (
-	configFile       string
-	pluginDir        string
-	continueDirectly bool
-	isDebug          bool
-	isForceDelete    bool
-
+	isDebug bool
 	rootCMD = &cobra.Command{
 		Use:   "dtm",
 		Short: `DevStream is an open-source DevOps toolchain manager`,

--- a/cmd/devstream/main.go
+++ b/cmd/devstream/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/devstream-io/devstream/internal/pkg/pluginengine"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
@@ -39,10 +38,6 @@ var (
 
 func init() {
 	cobra.OnInitialize(initConfig)
-
-	rootCMD.PersistentFlags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
-	rootCMD.PersistentFlags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir, "plugins directory")
-	rootCMD.PersistentFlags().BoolVarP(&continueDirectly, "yes", "y", false, "apply/delete directly without confirmation")
 	rootCMD.PersistentFlags().BoolVarP(&isDebug, "debug", "", false, "debug level log")
 	rootCMD.AddCommand(versionCMD)
 	rootCMD.AddCommand(initCMD)
@@ -88,6 +83,9 @@ func initConfig() {
 		log.Fatal(err)
 	}
 	if err := viper.BindPFlags(showStatusCMD.Flags()); err != nil {
+		log.Fatal(err)
+	}
+	if err := viper.BindPFlags(initCMD.Flags()); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/devstream/show.go
+++ b/cmd/devstream/show.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/devstream-io/devstream/internal/pkg/pluginengine"
 	"github.com/devstream-io/devstream/internal/pkg/show/config"
 	"github.com/devstream-io/devstream/internal/pkg/show/status"
 	"github.com/devstream-io/devstream/pkg/util/log"
@@ -56,8 +57,11 @@ func init() {
 	showCMD.AddCommand(showConfigCMD)
 	showCMD.AddCommand(showStatusCMD)
 
-	showConfigCMD.PersistentFlags().StringVarP(&plugin, "plugin", "p", "", "specify name with the plugin")
-	showStatusCMD.PersistentFlags().StringVarP(&plugin, "plugin", "p", "", "specify name with the plugin")
-	showStatusCMD.PersistentFlags().StringVarP(&instanceID, "id", "i", "", "specify id with the plugin instance")
-	showStatusCMD.PersistentFlags().BoolVarP(&statusAllFlag, "all", "a", false, "show all instances of all plugins status")
+	showConfigCMD.Flags().StringVarP(&plugin, "plugin", "p", "", "specify name with the plugin")
+
+	showStatusCMD.Flags().StringVarP(&plugin, "plugin", "p", "", "specify name with the plugin")
+	showStatusCMD.Flags().StringVarP(&instanceID, "id", "i", "", "specify id with the plugin instance")
+	showStatusCMD.Flags().BoolVarP(&statusAllFlag, "all", "a", false, "show all instances of all plugins status")
+	showStatusCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir, "plugins directory")
+	showStatusCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
 }

--- a/cmd/devstream/verify.go
+++ b/cmd/devstream/verify.go
@@ -22,3 +22,7 @@ func verifyCMDFunc(cmd *cobra.Command, args []string) {
 		log.Info("Verify finished.")
 	}
 }
+
+func init() {
+	verifyCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
+}

--- a/cmd/devstream/verify.go
+++ b/cmd/devstream/verify.go
@@ -25,4 +25,5 @@ func verifyCMDFunc(cmd *cobra.Command, args []string) {
 
 func init() {
 	verifyCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
+	verifyCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir, "plugins directory")
 }


### PR DESCRIPTION
Signed-off-by: sjie <sjie>
## Summary
Delete some global parameters. Some subcommands no longer have global parameters that should not appear
## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->
- Fix global parameters displayed on subcommands
## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->
- 🍀 Proposal: Some Commands Do Not Need the "-f" Parameter #559

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->
<img width="745" alt="image" src="https://user-images.githubusercontent.com/14817426/169840485-4550987d-f3dc-419a-a2b1-4ef640ed71ff.png">
<img width="783" alt="image" src="https://user-images.githubusercontent.com/14817426/169840683-f44ceab3-396c-4686-b995-b9886607adb9.png">
