### PR TITLE
feat(pluginengine): auto stop execution of changes when the dependent plugins fail

### DIFF
--- a/internal/pkg/configloader/config.go
+++ b/internal/pkg/configloader/config.go
@@ -72,6 +72,10 @@ func (t *Tool) DeepCopy() *Tool {
 	return &retTool
 }
 
+func (t *Tool) Key() string {
+	return fmt.Sprintf("%s.%s", t.Name, t.InstanceID)
+}
+
 // LoadConf reads an input file as a general config.
 func LoadConf(configFileName string) (*Config, error) {
 	configFileBytes, err := ioutil.ReadFile(configFileName)

--- a/internal/pkg/pluginengine/change.go
+++ b/internal/pkg/pluginengine/change.go
@@ -84,57 +84,74 @@ func execute(smgr statemanager.Manager, changes []*Change) map[string]error {
 	numOfChanges := len(changes)
 	log.Infof("Changes count: %d.", numOfChanges)
 
-	for i, c := range changes {
-		log.Separatorf("Processing progress: %d/%d.", i+1, numOfChanges)
-		log.Infof("Processing: (%s/%s) -> %s ...", c.Tool.Name, c.Tool.InstanceID, c.ActionName)
+	// get changes in batch
+	// the changes in each batch do not have dependency on each other
+	// but the changes from next batch have dependency on the changes from previous batch
+	batchesOfChanges, err := topologicalSortChangesInBatch(changes)
+	if err != nil {
+		log.Errorf("Failed to sort changes in batch: %s", err)
+		errorsMap["dependency-analysis"] = err
+		return errorsMap
+	}
 
-		var succeeded bool
-		var err error
-		var returnValue map[string]interface{}
+	for _, batch := range batchesOfChanges {
+		for i, c := range batch {
+			log.Separatorf("Processing progress: %d/%d.", i+1, numOfChanges)
+			log.Infof("Processing: (%s/%s) -> %s ...", c.Tool.Name, c.Tool.InstanceID, c.ActionName)
 
-		log.Debugf("Tool's raw changes are: %v.", c.Tool.Options)
+			var succeeded bool
+			var err error
+			var returnValue map[string]interface{}
 
-		errs := HandleOutputsReferences(smgr, c.Tool.Options)
-		if len(errs) != 0 {
-			succeeded = false
+			log.Debugf("Tool's raw changes are: %v.", c.Tool.Options)
 
-			for _, e := range errs {
-				log.Errorf("Error: %s.", e)
+			errs := HandleOutputsReferences(smgr, c.Tool.Options)
+			if len(errs) != 0 {
+				succeeded = false
+
+				for _, e := range errs {
+					log.Errorf("Error: %s.", e)
+				}
+				log.Errorf("The outputs reference in tool (%s/%s) can't be resolved. Please double check your config.", c.Tool.Name, c.Tool.InstanceID)
+
+				// not executing this change since its input isn't valid
+				continue
 			}
-			log.Errorf("The outputs reference in tool (%s/%s) can't be resolved. Please double check your config.", c.Tool.Name, c.Tool.InstanceID)
 
-			// not executing this change since its input isn't valid
-			continue
-		}
-
-		switch c.ActionName {
-		case statemanager.ActionCreate:
-			if returnValue, err = Create(c.Tool); err == nil {
-				succeeded = true
+			switch c.ActionName {
+			case statemanager.ActionCreate:
+				if returnValue, err = Create(c.Tool); err == nil {
+					succeeded = true
+				}
+			case statemanager.ActionUpdate:
+				if returnValue, err = Update(c.Tool); err == nil {
+					succeeded = true
+				}
+			case statemanager.ActionDelete:
+				succeeded, err = Delete(c.Tool)
 			}
-		case statemanager.ActionUpdate:
-			if returnValue, err = Update(c.Tool); err == nil {
-				succeeded = true
+
+			if err != nil {
+				key := fmt.Sprintf("%s/%s-%s", c.Tool.Name, c.Tool.InstanceID, c.ActionName)
+				errorsMap[key] = err
 			}
-		case statemanager.ActionDelete:
-			succeeded, err = Delete(c.Tool)
+
+			c.Result = &ChangeResult{
+				Succeeded:   succeeded,
+				Error:       err,
+				Time:        time.Now().Format(time.RFC3339),
+				ReturnValue: returnValue,
+			}
+
+			err = handleResult(smgr, c)
+			if err != nil {
+				errorsMap["handle-result"] = err
+			}
 		}
 
-		if err != nil {
-			key := fmt.Sprintf("%s/%s-%s", c.Tool.Name, c.Tool.InstanceID, c.ActionName)
-			errorsMap[key] = err
-		}
-
-		c.Result = &ChangeResult{
-			Succeeded:   succeeded,
-			Error:       err,
-			Time:        time.Now().Format(time.RFC3339),
-			ReturnValue: returnValue,
-		}
-
-		err = handleResult(smgr, c)
-		if err != nil {
-			errorsMap["handle-result"] = err
+		// abort next batches if any error occurred in this batch
+		if len(errorsMap) != 0 {
+			break
 		}
 	}
 	log.Separatorf("Processing done.")


### PR DESCRIPTION
… plugin fails

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](../CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description

solve #566

###Solution/behavior:

1. Topologically sort changes according to dependencies and split them into batches, each batch having multiple changes, using [topological_sort.go](https://github.com/devstream-io/devstream/blob/afe5e7277a981494743032a040464191b01f0ba7/internal/pkg/pluginengine/topological_sort.go#L30) .
2.  For example argocd and argocdapp belong to two batches. If an error occurs in changes apply, the err will be recorded in errsMap and will not affect other plugins in the same batch. But the excute of all changes of the next batch of plugins will be broken.

## Related Issues
close #566

## New Behavior (screenshots if needed)

I use `gitops.yaml` fot tests. (I comment `jira-github-integ` and `githubactions-golang`  because they have nothing to do with this bug)

Before:
![{F@`Z`1AUN9`CAK{2T0BAKL](https://user-images.githubusercontent.com/36830265/169997461-42cd9ae2-6576-49e3-992a-6a44a2825a6a.png)



After:
![TM2`{8W 7 HT9YRU%154M7Y](https://user-images.githubusercontent.com/36830265/169997481-8830382d-8178-41fe-8db7-c10f4b7f0fc4.png)

## About unit tests

I just used functions already in the project and added a simple loop, so I didn't write unit tests. 

If necessary, please let me know and I will write the test code.



