### PR TITLE
fix: trello-github variable name

### DIFF
--- a/test/e2e/yaml/e2e-trello-github-tools.yaml
+++ b/test/e2e/yaml/e2e-trello-github-tools.yaml
@@ -4,14 +4,14 @@ tools:
     dependsOn: [ ]
     options:
       org: [[ githubOrganization ]]
-      repo: [[ RepoName ]]
+      repo: [[ repoName ]]
       kanbanBoardName: [[ kanbanBoardName ]]
   - name: trello-github-integ
     instanceID: default
     dependsOn: [ "trello.default" ]
     options:
       org: [[ githubOrganization ]]
-      repo: [[ RepoName ]]
+      repo: [[ repoName ]]
       boardId: ${{ trello.default.outputs.boardId }}
       todoListId: ${{ trello.default.outputs.todoListId }}
       doingListId: ${{ trello.default.outputs.doingListId }}


### PR DESCRIPTION
Signed-off-by: KeHao <hao.ke@merico.dev>

## Description

fix:  RepoName -> repoName, the same as it in e2e-variables.yaml


