### PR TITLE
fix: avoid downloading development version plugins from remote

### DIFF
--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/spf13/viper"
 
@@ -30,10 +31,16 @@ func DownloadPlugins(conf *configloader.Config) error {
 	for _, tool := range conf.Tools {
 		pluginFileName := configloader.GetPluginFileName(&tool)
 		pluginMD5FileName := configloader.GetPluginMD5FileName(&tool)
+		// version regex
+		versionRegex := regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
 		// plugin does not exist
 		if _, err := os.Stat(filepath.Join(pluginDir, pluginFileName)); err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
 				return err
+			}
+			if !versionRegex.MatchString(version.Version) {
+				return fmt.Errorf("%s is not exist in %s, and it's the development version, no need to download from remote, please use the `make build-plugin.%s` command to rebuild the plugin in local", pluginFileName, pluginDir, tool.Name)
 			}
 			// download .so file
 			if err := dc.download(pluginDir, pluginFileName, version.Version); err != nil {

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -40,7 +40,7 @@ func DownloadPlugins(conf *configloader.Config) error {
 				return err
 			}
 			if !versionRegex.MatchString(version.Version) {
-				return fmt.Errorf("%s is not exist in %s, and it's the development version, no need to download from remote, please use the `make build-plugin.%s` command to rebuild the plugin in local", pluginFileName, pluginDir, tool.Name)
+				return fmt.Errorf("%s (dev version) not exist in the local plugins dir "%s". Dev version plugins can't be downloaded from the remote plugin repo; please run `make build-plugin.%s` to build it locally", pluginFileName, pluginDir, tool.Name)
 			}
 			// download .so file
 			if err := dc.download(pluginDir, pluginFileName, version.Version); err != nil {


### PR DESCRIPTION
## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

when there are old development version plugins in `.devstream`, then your change your code, and when you build plugins, they will have a new version number, then executing`dtm init` will report the following error. We need to make sure that only the official release version needs to be downloaded from remote.

```bash
❌ 😭 ./dtm init
2022-05-27 22:03:02 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-05-27 22:03:05 ✖ [ERROR]  [gitlab-repo-scaffolding-golang-darwin-arm64_0.5.0-216-gc6b4aba.so] download failed, 403 Forbidden.
2022-05-27 22:03:05 ✖ [ERROR]  Remove [.devstream/gitlab-repo-scaffolding-golang-darwin-arm64_0.5.0-216-gc6b4aba.so.tmp] failed, remove .devstream/gitlab-repo-scaffolding-golang-darwin-arm64_0.5.0-216-gc6b4aba.so.tmp: no such file or directory.
2022-05-27 22:03:05 ✖ [ERROR]  Error: downloading gitlab-repo-scaffolding-golang-darwin-arm64_0.5.0-216-gc6b4aba.so from https://download.devstream.io/v0.5.0-216-gc6b4aba/gitlab-repo-scaffolding-golang-darwin-arm64_0.5.0-216-gc6b4aba.so status code 403.
```

## Related Issues

Closes 630

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/16207029/170734228-7aad6a2f-6907-4a8b-a9ce-34569befe9f1.png">
