### PR TITLE
fix: generate default config file

### DIFF
--- a/internal/pkg/develop/plugin/template/config.go
+++ b/internal/pkg/develop/plugin/template/config.go
@@ -1,10 +1,17 @@
 package template
 
-var config_go_nameTpl = "{{ .Name }}.go"
-var config_go_dirTpl = "internal/pkg/show/config/plugin/"
-var config_go_contentTpl = `package plugin
-
-// TODO(dtm): Add your default config here.
+var config_go_nameTpl = "{{ .Name }}.yaml"
+var config_go_dirTpl = "internal/pkg/show/config/plugins/"
+var config_go_contentTpl = `tools:
+# name of the tool
+- name: {{ .Name }}
+  # id of the tool instance
+  instanceID: default
+  # format: name.instanceID; If specified, dtm will make sure the dependency is applied first before handling this tool.
+  dependsOn: [ ]
+  # options for the plugin
+  options:
+  # TODO(dtm): Add your default config here.
 `
 
 func init() {


### PR DESCRIPTION
## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

The default config already uses `go:embed` to implement ( #614 ), default config is `pluginname.yaml`, and it's in `internal/pkg/show/config/plugins/`, but the `develop create-plugin`  subcommand hasn't updated this part of the code yet

## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->
- Generate a default configuration file for the plugin in the `internal/pkg/show/config/plugins/` directory