### PR TITLE
feat: new plugin - tekton 

### DIFF
--- a/cmd/plugin/tekton/main.go
+++ b/cmd/plugin/tekton/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/devstream-io/devstream/internal/pkg/plugin/tekton"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+// NAME is the name of this DevStream plugin.
+const NAME = "tekton"
+
+// Plugin is the type used by DevStream core. It's a string.
+type Plugin string
+
+// Create implements the create of tekton.
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
+	return tekton.Create(options)
+}
+
+// Update implements the update of tekton.
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
+	return tekton.Update(options)
+}
+
+// Delete implements the delete of tekton.
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
+	return tekton.Delete(options)
+}
+
+// Read implements the read of tekton.
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
+	return tekton.Read(options)
+}
+
+// DevStreamPlugin is the exported variable used by the DevStream core.
+var DevStreamPlugin Plugin
+
+func main() {
+	log.Infof("%T: %s is a plugin for DevStream. Use it with DevStream.\n", DevStreamPlugin, NAME)
+}

--- a/docs/plugins/tekton.md
+++ b/docs/plugins/tekton.md
@@ -1,0 +1,42 @@
+# tekton Plugin
+This plugin installs [tekton]("https://tekton.dev/") in an existing Kubernetes cluster using the Helm chart.
+
+## Usage
+
+```yaml
+tools:
+  # name of the tool
+  - name: tekton
+    # id of the tool instance
+    instanceID: default
+    # format: name.instanceID; If specified, dtm will make sure the dependency is applied first before handling this tool.
+    dependsOn: [ ]
+    # options for the plugin
+    options:
+      # need to create the namespace or not, default: false
+      create_namespace: true
+      repo:
+        # name of the Helm repo
+        name: tekton
+        # url of the Helm repo, use self host helm config beacuse official helm does'nt support namespace config
+        url: https://steinliber.github.io/tekton-helm-chart/
+      # Helm chart information
+      chart:
+        # name of the chart
+        chart_name: tekton/tekton-pipeline
+        # k8s namespace where Tekton will be installed
+        namespace: tekton
+        # release name of the chart
+        release_name: tekton
+        # whether to wait for the release to be deployed or not
+        wait: true
+        # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 5m0s
+        timeout: 5m
+        # whether to perform a CRD upgrade during installation
+        upgradeCRDs: true
+        values_yaml: |
+          serviceaccount:
+            enabled: true
+```
+
+Currently, except for `values_yaml`, all the parameters in the example above are mandatory.

--- a/internal/pkg/plugin/common/helm/helm.go
+++ b/internal/pkg/plugin/common/helm/helm.go
@@ -90,3 +90,7 @@ func DealWithNsWhenInterruption(opts *Options) error {
 	log.Debugf("The namespace %s has been deleted.", opts.Chart.Namespace)
 	return nil
 }
+
+func GetAnnotationName() string {
+	return "meta.helm.sh/release-name"
+}

--- a/internal/pkg/plugin/tekton/create.go
+++ b/internal/pkg/plugin/tekton/create.go
@@ -1,0 +1,47 @@
+package tekton
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+
+	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
+	var opts Options
+	if err := mapstructure.Decode(options, &opts); err != nil {
+		return nil, err
+	}
+
+	if errs := validate(&opts); len(errs) != 0 {
+		for _, e := range errs {
+			log.Errorf("Options error: %s.", e)
+		}
+		return nil, fmt.Errorf("opts are illegal")
+	}
+
+	if err := DealWithNsWhenInstall(&opts); err != nil {
+		return nil, err
+	}
+	var retErr error
+	// delete namespace if encounter error
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		if err := DealWithNsWhenInterruption(&opts); err != nil {
+			log.Errorf("Failed to deal with namespace: %s.", err)
+		}
+		log.Debugf("Deal with namespace when interruption succeeded.")
+	}()
+
+	if retErr = InstallOrUpgradeChart(&opts); retErr != nil {
+		return nil, retErr
+	}
+
+	retMap := GetStaticState().ToStringInterfaceMap()
+	log.Debugf("Return map: %v", retMap)
+	return retMap, nil
+}

--- a/internal/pkg/plugin/tekton/delete.go
+++ b/internal/pkg/plugin/tekton/delete.go
@@ -1,0 +1,41 @@
+package tekton
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+
+	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+	"github.com/devstream-io/devstream/pkg/util/helm"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+func Delete(options map[string]interface{}) (bool, error) {
+	var opts Options
+	if err := mapstructure.Decode(options, &opts); err != nil {
+		return false, err
+	}
+
+	if errs := validate(&opts); len(errs) != 0 {
+		for _, e := range errs {
+			log.Errorf("Options error: %s.", e)
+		}
+		return false, fmt.Errorf("opts are illegal")
+	}
+
+	h, err := helm.NewHelm(opts.GetHelmParam())
+	if err != nil {
+		return false, err
+	}
+	log.Info("Uninstalling tekton helm chart.")
+
+	if err = h.UninstallHelmChartRelease(); err != nil {
+		return false, err
+	}
+
+	//delete ns if tekton is deleted
+	if err := DealWithNsWhenInterruption(&opts); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/pkg/plugin/tekton/read.go
+++ b/internal/pkg/plugin/tekton/read.go
@@ -1,0 +1,33 @@
+package tekton
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+
+	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
+	var opts Options
+	if err := mapstructure.Decode(options, &opts); err != nil {
+		return nil, err
+	}
+
+	if errs := validate(&opts); len(errs) != 0 {
+		for _, e := range errs {
+			log.Errorf("Options error: %s.", e)
+		}
+		return nil, fmt.Errorf("opts are illegal")
+	}
+
+	retState, err := GetDynamicState(&opts)
+	if err != nil {
+		return nil, err
+	}
+	retMap := retState.ToStringInterfaceMap()
+	log.Debugf("Return map: %v.", retMap)
+
+	return retMap, nil
+}

--- a/internal/pkg/plugin/tekton/state.go
+++ b/internal/pkg/plugin/tekton/state.go
@@ -1,0 +1,56 @@
+package tekton
+
+import (
+	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+	"github.com/devstream-io/devstream/pkg/util/helm"
+	"github.com/devstream-io/devstream/pkg/util/k8s"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+var DefaultDeploymentList = []string{
+	"tekton-pipelines-controller",
+	"tekton-pipelines-webhook",
+}
+
+func GetStaticState() *helm.InstanceState {
+	retState := &helm.InstanceState{}
+	for _, dpName := range DefaultDeploymentList {
+		retState.Workflows.AddDeployment(dpName, true)
+	}
+	return retState
+}
+
+func GetDynamicState(opts *Options) (*helm.InstanceState, error) {
+	namespace := getOrDefaultNamespace(opts.Chart.Namespace)
+	kubeClient, err := k8s.NewClient()
+	if err != nil {
+		return nil, err
+	}
+
+	dps, err := kubeClient.ListDeployments(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	retState := &helm.InstanceState{}
+	for _, dp := range dps {
+		dpAn := dp.GetAnnotations()
+		dpName := dp.GetName()
+		helmNameAn, exist := dpAn[GetAnnotationName()]
+		if !exist || helmNameAn != opts.Chart.ReleaseName {
+			log.Infof("Found unknown deployment: %s.", dp.GetName())
+		}
+		ready := kubeClient.IsDeploymentReady(&dp)
+		retState.Workflows.AddDeployment(dpName, ready)
+		log.Debugf("The deployment %s is %t.", dp.GetName(), ready)
+	}
+	return retState, err
+}
+
+func getOrDefaultNamespace(namespace string) string {
+	if namespace == "" {
+		//tekon is default namespace
+		namespace = "tekon"
+	}
+	return namespace
+}

--- a/internal/pkg/plugin/tekton/tekton.go
+++ b/internal/pkg/plugin/tekton/tekton.go
@@ -1,0 +1,3 @@
+package tekton
+
+// TODO(dtm): Add your logic here.

--- a/internal/pkg/plugin/tekton/update.go
+++ b/internal/pkg/plugin/tekton/update.go
@@ -1,0 +1,36 @@
+package tekton
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+
+	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
+	var opts Options
+	if err := mapstructure.Decode(options, &opts); err != nil {
+		return nil, err
+	}
+
+	if errs := validate(&opts); len(errs) != 0 {
+		for _, e := range errs {
+			log.Errorf("Options error: %s.", e)
+		}
+		return nil, fmt.Errorf("opts are illegal")
+	}
+
+	// install or upgrade
+	if err := InstallOrUpgradeChart(&opts); err != nil {
+		return nil, err
+	}
+
+	// fill the return map
+	retMap := GetStaticState().ToStringInterfaceMap()
+	log.Debugf("Return map: %v", retMap)
+
+	return retMap, nil
+}

--- a/internal/pkg/plugin/tekton/validate.go
+++ b/internal/pkg/plugin/tekton/validate.go
@@ -1,0 +1,11 @@
+package tekton
+
+import (
+	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+	"github.com/devstream-io/devstream/pkg/util/helm"
+)
+
+// validate validates the options provided by the core.
+func validate(opts *Options) []error {
+	return helm.Validate(opts.GetHelmParam())
+}

--- a/internal/pkg/show/config/plugins/tekton.yaml
+++ b/internal/pkg/show/config/plugins/tekton.yaml
@@ -1,0 +1,33 @@
+tools:
+  # name of the tool
+  - name: tekton
+    # id of the tool instance
+    instanceID: default
+    # format: name.instanceID; If specified, dtm will make sure the dependency is applied first before handling this tool.
+    dependsOn: [ ]
+    # options for the plugin
+    options:
+      # need to create the namespace or not, default: false
+      create_namespace: true
+      repo:
+        # name of the Helm repo
+        name: tekton
+        # url of the Helm repo, use self host helm config beacuse official helm does'nt support namespace config
+        url: https://steinliber.github.io/tekton-helm-chart/
+      # Helm chart information
+      chart:
+        # name of the chart
+        chart_name: tekton/tekton-pipeline
+        # k8s namespace where Tekton will be installed
+        namespace: tekton
+        # release name of the chart
+        release_name: tekton
+        # whether to wait for the release to be deployed or not
+        wait: true
+        # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 5m0s
+        timeout: 5m
+        # whether to perform a CRD upgrade during installation
+        upgradeCRDs: true
+        values_yaml: |
+          serviceaccount:
+            enabled: true

--- a/internal/pkg/show/status/status.go
+++ b/internal/pkg/show/status/status.go
@@ -78,7 +78,9 @@ func showAll(smgr statemanager.Manager) error {
 // show one plugin status
 func showOne(smgr statemanager.Manager, id, plugin string) error {
 	// get state from statemanager
-	state := smgr.GetState(statemanager.GenerateStateKeyByToolNameAndPluginKind(id, plugin))
+	state := smgr.GetState(
+		statemanager.GenerateStateKeyByToolNameAndPluginKind(plugin, id),
+	)
 	if state == nil {
 		return fmt.Errorf("state with (id: %s, plugin: %s) not found", id, plugin)
 	}


### PR DESCRIPTION
# Summary
## Key Points
Support tekton plugin installed using helm.
## Description
- new plugin: tekton
- it takes three option inputs: chart, repo and create_namespace
- it get helm template from repo and install tekton using chart variable
- docs are also updated
- added to dtm show as well