### PR TITLE
chore: add golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+# options for analysis running
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 5m
+


### PR DESCRIPTION
## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

- Integrate the `golangci-lint` command in the makefile, so that we can use it to test code quality in local
- Add `golangci-lint` config file, maybe we can add more rules in this file in the future

## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->
#632 

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->

``` bash
✅ 😁 make lint 
Run golangci to lint source codes
```