### PR TITLE
Update Symbol.go

### DIFF
--- a/pkg/util/log/symbol.go
+++ b/pkg/util/log/symbol.go
@@ -18,16 +18,16 @@ type Symbols struct {
 }
 
 var normal = Symbols{
-	Debug:   Symbol("ℹ"),
+	Debug:   Symbol("λ"),
 	Info:    Symbol("ℹ"),
 	Success: Symbol("✔"),
 	Warning: Symbol("⚠"),
 	Warn:    Symbol("⚠"),
-	Error:   Symbol("✖"),
+	Error:   Symbol("!!"),
 	Fatal:   Symbol("✖"),
 }
 
 // String returns a printable representation of Symbols struct
 func (s Symbols) String() string {
-	return fmt.Sprintf("Info: %s Success: %s Warning: %s Error: %s", s.Info, s.Success, s.Warning, s.Error)
+	return fmt.Sprintf("Debug: %s Info: %s Success: %s Warning: %s Error: %s Fatal: %s",s.Debug s.Info, s.Success, s.Warning, s.Error, s.Fatal)
 }


### PR DESCRIPTION
## Pre-Checklist


## Description
style : Change Symbol Type of logging levels

Debug and Error were having same symbol type so updating it that makes more differentiating and more appealing.
Symbol of Debug and Info was  ( i ) also Error and Fatal was  ( x ) so making Debug to ( λ ) and Error to ( !! )

## Related Issues
#646 


