### PR TITLE
fix: plugin default path

### DIFF
--- a/cmd/devstream/apply.go
+++ b/cmd/devstream/apply.go
@@ -30,7 +30,7 @@ func applyCMDFunc(cmd *cobra.Command, args []string) {
 
 func init() {
 	applyCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
-	applyCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir, "plugins directory")
+	applyCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir(), "plugins directory")
 	applyCMD.Flags().BoolVarP(&continueDirectly, "yes", "y", false, "apply directly without confirmation")
 
 	completion.FlagConfigFileCompletion(applyCMD)

--- a/cmd/devstream/delete.go
+++ b/cmd/devstream/delete.go
@@ -33,7 +33,7 @@ func deleteCMDFunc(cmd *cobra.Command, args []string) {
 func init() {
 	deleteCMD.Flags().BoolVarP(&isForceDelete, "force", "", false, "force delete by config")
 	deleteCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
-	deleteCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir, "plugins directory")
+	deleteCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir(), "plugins directory")
 	deleteCMD.Flags().BoolVarP(&continueDirectly, "yes", "y", false, "delete directly without confirmation")
 
 	completion.FlagConfigFileCompletion(applyCMD)

--- a/cmd/devstream/init.go
+++ b/cmd/devstream/init.go
@@ -35,7 +35,7 @@ func initCMDFunc(cmd *cobra.Command, args []string) {
 
 func init() {
 	initCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
-	initCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir, "plugins directory")
+	initCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir(), "plugins directory")
 
 	completion.FlagConfigFileCompletion(initCMD)
 }

--- a/cmd/devstream/show.go
+++ b/cmd/devstream/show.go
@@ -64,7 +64,7 @@ func init() {
 	showStatusCMD.Flags().StringVarP(&plugin, "plugin", "p", "", "specify name with the plugin")
 	showStatusCMD.Flags().StringVarP(&instanceID, "id", "i", "", "specify id with the plugin instance")
 	showStatusCMD.Flags().BoolVarP(&statusAllFlag, "all", "a", false, "show all instances of all plugins status")
-	showStatusCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir, "plugins directory")
+	showStatusCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir(), "plugins directory")
 	showStatusCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
 	completion.FlagPluginsCompletion(showStatusCMD, "plugin")
 }

--- a/cmd/devstream/verify.go
+++ b/cmd/devstream/verify.go
@@ -26,7 +26,7 @@ func verifyCMDFunc(cmd *cobra.Command, args []string) {
 
 func init() {
 	verifyCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
-	verifyCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir, "plugins directory")
+	verifyCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir(), "plugins directory")
 
 	completion.FlagConfigFileCompletion(verifyCMD)
 }

--- a/internal/pkg/pluginengine/plugin.go
+++ b/internal/pkg/pluginengine/plugin.go
@@ -1,10 +1,17 @@
 package pluginengine
 
 import (
+	"path/filepath"
+
+	"k8s.io/client-go/util/homedir"
+
 	"github.com/devstream-io/devstream/internal/pkg/configloader"
 )
 
-const DefaultPluginDir = ".devstream"
+// DefaultPluginDir The default path of the plugin is in the user's home directory
+func DefaultPluginDir() string {
+	return filepath.Join(homedir.HomeDir(), ".devstream")
+}
 
 // DevStreamPlugin is a struct, on which Create/Read/Update/Delete interfaces are defined.
 type DevStreamPlugin interface {

--- a/internal/pkg/pluginengine/plugin_helper.go
+++ b/internal/pkg/pluginengine/plugin_helper.go
@@ -12,7 +12,7 @@ import (
 func getPluginDir() string {
 	var pluginDir string
 	if pluginDir = viper.GetString("plugin-dir"); pluginDir == "" {
-		pluginDir = DefaultPluginDir
+		pluginDir = DefaultPluginDir()
 	}
 	return pluginDir
 }


### PR DESCRIPTION
Signed-off-by: prodan <pengshihaoren@gmail.com>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

If the default path of the plugin is the current `.devstream`, if the user switches the directory, the plugin needs to be downloaded again.

The user configuration of cloud native software is generally in the user's home directory by default.
## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->
#752
## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->

```bash
prodan@ubuntu:/opt/workspaces/devstream$ ./dtm apply -h
Create or update DevOps tools according to DevStream configuration file.
DevStream will generate and execute a new plan based on the config file and the state file by default.

Usage:
  dtm apply [flags]

Flags:
  -f, --config-file string   config file (default "config.yaml")
  -h, --help                 help for apply
  -d, --plugin-dir string    plugins directory (default "/home/prodan/.devstream")
  -y, --yes                  apply directly without confirmation

Global Flags:
      --debug   debug level log
```
