### PR TITLE
feat: `jenkins` plugin prod ready

### DIFF
--- a/docs/best-practices/gitops.md
+++ b/docs/best-practices/gitops.md
@@ -30,7 +30,7 @@ The dependencies of these plugins are(`a -> b` means for `a depends on b`):
 
 Note: These dependencies are optional; you can use dependency to make sure a certain tool is installed before another. We should use dependency according to the actual usage situation.
 
-## Download DevStream (`dtm`)
+## 1 Download DevStream (`dtm`)
 
 Download the appropriate `dtm` version for your platform from [DevStream Releases](https://github.com/devstream-io/devstream/releases).
 
@@ -38,7 +38,7 @@ Download the appropriate `dtm` version for your platform from [DevStream Release
 
 > Once downloaded, you can run the binary from anywhere. Ideally, you want to put it in a place that is in your PATH (e.g., `/usr/local/bin`).
 
-## Prepare the Config File
+## 2 Prepare the Config File
 
 Download the `gitops.yaml` to your working directory:
 
@@ -77,7 +77,7 @@ If you don't know how to create these three tokens, check out:
 - JIRA_API_TOKEN: [Creating a personal access token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
 - DOCKERHUB_TOKEN: [Manage access tokens](https://docs.docker.com/docker-hub/access-tokens/)
 
-## 3. Initialize
+## 3 Initialize
 
 Run:
 
@@ -85,7 +85,7 @@ Run:
 dtm init -f gitops.yaml
 ```
 
-## 4. Apply
+## 4 Apply
 
 Run:
 
@@ -101,7 +101,7 @@ and confirm to continue, then you should see similar output to:
 2022-03-11 13:36:11 ✔ [SUCCESS]  Apply finished.
 ```
 
-## 5. Check the Results
+## 5 Check the Results
 
 Let's continue to look at the results of the `apply` command.
 
@@ -155,7 +155,7 @@ Let's continue to look at the results of the `apply` command.
 
 ![](i.png)
 
-## 6. Clean Up
+## 6 Clean Up
 
 Run:
 

--- a/docs/plugins/jenkins.md
+++ b/docs/plugins/jenkins.md
@@ -7,7 +7,7 @@ This plugin installs [jenkins](https://jenkins.io) in an existing Kubernetes clu
 ### NOTICE
 
 #### Production Environments
-Please be sure to change the `storageClass` in the configuration item to an existing storage class.
+Please be sure to change the `storageClass` in the configuration item to an existing StorageClass.
 
 #### Test Environments
 If you want to **test** the plugin in a **local environment**:
@@ -17,19 +17,23 @@ If you want to **test** the plugin in a **local environment**:
 
 ```bash
 # If you run k8s and dtm in the same host
-mkdir -p ~/data/jenkins-volumes/
-chown -R 1000:1000 ~/data/jenkins-volumes/
+mkdir -p ~/data/jenkins-volume/
+chown -R 1000:1000 ~/data/jenkins-volume/
 
 -------------------------
 
 # If you run k8s and dtm in different hosts, such as run k8s in docker
-# 1. Get the home directory of the user who runs dtm
+# 1 Get the home directory of the user who runs dtm
 cd ~ && pwd
-# 2. Copy the result of the above command
-# 3. Create the data directory manually in the host where kubernetes is running:
-docker exec -it <container-id> bash
-mkdir -p <your-dtm-home-dir>/data/jenkins-volumes/
-chown -R 1000:1000 <your-dtm-home-dir>/data/jenkins-volumes/
+# 2 Copy the result of the above command
+# 3 Enter the host on which k8s is running
+  # 3.1 for minikube
+  minikube ssh
+  # 3.2 for kind
+  docker exec -it <kind-container-name-or-id> bash
+# 4 Create the data directory manually in the host where kubernetes is running:
+mkdir -p <your-dtm-home-dir>/data/jenkins-volume/
+chown -R 1000:1000 <your-dtm-home-dir>/data/jenkins-volume/
 ```
 
 ### Config

--- a/docs/plugins/jenkins.md
+++ b/docs/plugins/jenkins.md
@@ -4,14 +4,35 @@ This plugin installs [jenkins](https://jenkins.io) in an existing Kubernetes clu
 
 ## Usage
 
-NOTICE:
+### NOTICE
 
-Create the data directory manually:
+#### Production Environments
+Please be sure to change the `storageClass` in the configuration item to an existing storage class.
+
+#### Test Environments
+If you want to **test** the plugin in a **local environment**:
+
+1. Please change the `test_env` to `true` in the config file.
+2. Create the data directory manually in the host where kubernetes is running:
 
 ```bash
+# If you run k8s and dtm in the same host
 mkdir -p ~/data/jenkins-volumes/
 chown -R 1000:1000 ~/data/jenkins-volumes/
+
+-------------------------
+
+# If you run k8s and dtm in different hosts, such as run k8s in docker
+# 1. Get the home directory of the user who runs dtm
+cd ~ && pwd
+# 2. Copy the result of the above command
+# 3. Create the data directory manually in the host where kubernetes is running:
+docker exec -it <container-id> bash
+mkdir -p <your-dtm-home-dir>/data/jenkins-volumes/
+chown -R 1000:1000 <your-dtm-home-dir>/data/jenkins-volumes/
 ```
+
+### Config
 
 ```yaml
 --8<-- "jenkins.yaml"

--- a/docs/plugins/jenkins.zh.md
+++ b/docs/plugins/jenkins.zh.md
@@ -7,7 +7,7 @@
 ### 注意
 
 #### 生产环境
-请将配置中的 `storageClass` 修改为已存在的 storage class.
+请将配置中的 `storageClass` 修改为已存在的 StorageClass.
 
 #### 测试环境
 如果你想**在本地测试插件**：
@@ -17,22 +17,24 @@
 
 ```bash
 # 如果 k8s 和 dtm 运行在同一个主机上
-mkdir -p ~/data/jenkins-volumes/
-chown -R 1000:1000 ~/data/jenkins-volumes/
+mkdir -p ~/data/jenkins-volume/
+chown -R 1000:1000 ~/data/jenkins-volume/
 
 -------------------------
 
 # 如果 k8s 和 dtm 运行在不同的主机上，比如 k8s 运行在 docker 中
-# 1. 获取 dtm 运行的主机的用户的 home 目录
+# 1 获取 dtm 运行的主机的用户的 home 目录
 cd ~ && pwd
-# 2. 复制上面的命令结果
-# 3. 在 k8s 运行的主机上创建数据目录并修改权限，命令如下：
-docker exec -it <container-id> bash
-mkdir -p <your-dtm-home-dir>/data/jenkins-volumes/
-chown -R 1000:1000 <your-dtm-home-dir>/data/jenkins-volumes/
+# 2 复制上面的命令结果
+# 3 进入运行着 k8s 的主机
+  # 3.1 如果你是 minikube
+  minikube ssh
+  # 3.2 如果你是 kind
+  docker exec -it <kind-container-name-or-id> bash
+# 4. 在 k8s 运行的主机上创建数据目录并修改权限，命令如下：
+mkdir -p <your-dtm-home-dir>/data/jenkins-volume/
+chown -R 1000:1000 <your-dtm-home-dir>/data/jenkins-volume/
 ```
-
-
 
 ### 配置
 

--- a/docs/plugins/jenkins.zh.md
+++ b/docs/plugins/jenkins.zh.md
@@ -1,3 +1,43 @@
 # jenkins 插件
 
-todo
+本插件使用 helm 在已有的 k8s 集群上安装 [jenkins](https://jenkins.io)。
+
+## 使用方法
+
+### 注意
+
+#### 生产环境
+请将配置中的 `storageClass` 修改为已存在的 storage class.
+
+#### 测试环境
+如果你想**在本地测试插件**：
+
+1. 请将配置文件中的 `test_env` 改为 `true`。
+2. 在运行 k8s 的主机上创建数据目录并修改权限，命令如下：
+
+```bash
+# 如果 k8s 和 dtm 运行在同一个主机上
+mkdir -p ~/data/jenkins-volumes/
+chown -R 1000:1000 ~/data/jenkins-volumes/
+
+-------------------------
+
+# 如果 k8s 和 dtm 运行在不同的主机上，比如 k8s 运行在 docker 中
+# 1. 获取 dtm 运行的主机的用户的 home 目录
+cd ~ && pwd
+# 2. 复制上面的命令结果
+# 3. 在 k8s 运行的主机上创建数据目录并修改权限，命令如下：
+docker exec -it <container-id> bash
+mkdir -p <your-dtm-home-dir>/data/jenkins-volumes/
+chown -R 1000:1000 <your-dtm-home-dir>/data/jenkins-volumes/
+```
+
+
+
+### 配置
+
+```yaml
+--8<-- "jenkins.yaml"
+```
+
+当前，所有配置项均为必填。

--- a/internal/pkg/plugin/jenkins/create.go
+++ b/internal/pkg/plugin/jenkins/create.go
@@ -62,7 +62,7 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	log.Debugf("Return map: %v.", retMap)
 
 	// show how to get pwd of the admin user
-	howToGetPwdOfAdmin(&opts)
+	howToGetPasswdOfAdmin(&opts)
 
 	// show jenkins url
 	showJenkinsUrl(&opts)

--- a/internal/pkg/plugin/jenkins/create.go
+++ b/internal/pkg/plugin/jenkins/create.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+	"github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
@@ -25,7 +25,7 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	}
 
 	// 2. deal with ns
-	if err := DealWithNsWhenInstall(&opts); err != nil {
+	if err := helm.DealWithNsWhenInstall(&opts.Options); err != nil {
 		return nil, err
 	}
 
@@ -34,7 +34,7 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		if retErr == nil {
 			return
 		}
-		if err := DealWithNsWhenInterruption(&opts); err != nil {
+		if err := helm.DealWithNsWhenInterruption(&opts.Options); err != nil {
 			log.Errorf("Failed to deal with namespace: %s.", err)
 		}
 		log.Debugf("Deal with namespace when interruption succeeded.")
@@ -46,13 +46,13 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	}()
 
 	// 3. pre-create
-	if retErr = preCreate(); retErr != nil {
+	if retErr = preCreate(opts); retErr != nil {
 		log.Errorf("The pre-create logic failed: %s.", retErr)
 		return nil, retErr
 	}
 
 	// 4. install or upgrade
-	if retErr = InstallOrUpgradeChart(&opts); retErr != nil {
+	if retErr = helm.InstallOrUpgradeChart(&opts.Options); retErr != nil {
 		return nil, retErr
 	}
 
@@ -60,6 +60,12 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	releaseName := opts.Chart.ReleaseName
 	retMap := GetStaticState(releaseName).ToStringInterfaceMap()
 	log.Debugf("Return map: %v.", retMap)
+
+	// show how to get pwd of the admin user
+	howToGetPwdOfAdmin(&opts)
+
+	// show jenkins url
+	showJenkinsUrl(&opts)
 
 	return retMap, nil
 }

--- a/internal/pkg/plugin/jenkins/delete.go
+++ b/internal/pkg/plugin/jenkins/delete.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
 	"github.com/devstream-io/devstream/pkg/util/helm"
 	"github.com/devstream-io/devstream/pkg/util/k8s"
 	"github.com/devstream-io/devstream/pkg/util/log"

--- a/internal/pkg/plugin/jenkins/jenkins_suite_test.go
+++ b/internal/pkg/plugin/jenkins/jenkins_suite_test.go
@@ -1,0 +1,13 @@
+package jenkins_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestJenkins(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Jenkins Suite")
+}

--- a/internal/pkg/plugin/jenkins/options.go
+++ b/internal/pkg/plugin/jenkins/options.go
@@ -1,0 +1,9 @@
+package jenkins
+
+import "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+
+type Options struct {
+	// in test env, we will use hostpath to auto create persistent volume
+	TestEnv      bool `mapstructure:"test_env"`
+	helm.Options `mapstructure:",squash"`
+}

--- a/internal/pkg/plugin/jenkins/precreate.go
+++ b/internal/pkg/plugin/jenkins/precreate.go
@@ -16,7 +16,7 @@ import (
 const (
 	JenkinsName                      = "jenkins"
 	JenkinsNamespace                 = "jenkins"
-	JenkinsDataDirectory             = "/data/jenkins-volumes/"
+	JenkinsDataDirectory             = "/data/jenkins-volume/"
 	JenkinsPvName                    = "jenkins-pv"
 	JenkinsPvDefaultStorageClassName = "jenkins-pv"
 )

--- a/internal/pkg/plugin/jenkins/prompt.go
+++ b/internal/pkg/plugin/jenkins/prompt.go
@@ -1,0 +1,36 @@
+package jenkins
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+func howToGetPwdOfAdmin(opts *Options) {
+	log.Info("Here is how to get the password of the admin user:")
+	method := fmt.Sprintf("kubectl exec --namespace jenkins -it svc/%s-jenkins -c jenkins "+
+		"-- /bin/cat /run/secrets/additional/chart-admin-password && echo", opts.Chart.ReleaseName)
+	log.Info(method)
+}
+
+func showJenkinsUrl(opts *Options) {
+	commands := []string{
+		`jsonpath="{.spec.ports[0].nodePort}"`,
+		fmt.Sprintf(`NODE_PORT=$(kubectl get -n jenkins -o jsonpath=$jsonpath services %s-jenkins)`, opts.Chart.ReleaseName),
+		`jsonpath="{.items[0].status.addresses[0].address}"`,
+		`NODE_IP=$(kubectl get nodes -n jenkins -o jsonpath=$jsonpath)`,
+		`echo http://$NODE_IP:$NODE_PORT/login`,
+	}
+
+	cmd := exec.Command("sh", "-c", strings.Join(commands, " && "))
+
+	output, err := cmd.Output()
+	if err != nil {
+		log.Errorf("Failed to get jenkins url: %v", err)
+	}
+
+	log.Info("Jenkins url:", string(output))
+
+}

--- a/internal/pkg/plugin/jenkins/prompt.go
+++ b/internal/pkg/plugin/jenkins/prompt.go
@@ -8,7 +8,7 @@ import (
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
-func howToGetPwdOfAdmin(opts *Options) {
+func howToGetPasswdOfAdmin(opts *Options) {
 	log.Info("Here is how to get the password of the admin user:")
 	method := fmt.Sprintf("kubectl exec --namespace jenkins -it svc/%s-jenkins -c jenkins "+
 		"-- /bin/cat /run/secrets/additional/chart-admin-password && echo", opts.Chart.ReleaseName)

--- a/internal/pkg/plugin/jenkins/read.go
+++ b/internal/pkg/plugin/jenkins/read.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"k8s.io/utils/strings/slices"
 
-	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
 	"github.com/devstream-io/devstream/pkg/util/helm"
 	"github.com/devstream-io/devstream/pkg/util/k8s"
 	"github.com/devstream-io/devstream/pkg/util/log"

--- a/internal/pkg/plugin/jenkins/update.go
+++ b/internal/pkg/plugin/jenkins/update.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+	"github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
@@ -25,7 +25,7 @@ func Update(options map[string]interface{}) (map[string]interface{}, error) {
 	}
 
 	// 2. install or upgrade
-	if err := InstallOrUpgradeChart(&opts); err != nil {
+	if err := helm.InstallOrUpgradeChart(&opts.Options); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/plugin/jenkins/validate.go
+++ b/internal/pkg/plugin/jenkins/validate.go
@@ -1,11 +1,44 @@
 package jenkins
 
 import (
-	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+	"fmt"
+	"regexp"
+
 	"github.com/devstream-io/devstream/pkg/util/helm"
+	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
 // validate validates the options provided by the core.
 func validate(opts *Options) []error {
-	return helm.Validate(opts.GetHelmParam())
+	errs := helm.Validate(opts.GetHelmParam())
+	if len(errs) != 0 {
+		return errs
+	}
+
+	// if dev mode, replace the storage class name with default storage class which is auto created with hostpath type.
+	if opts.TestEnv {
+		chartNew := opts.Chart
+		var err error
+		chartNew.ValuesYaml, err = ReplaceStorageClass(opts.Chart.ValuesYaml)
+		if err != nil {
+			return []error{err}
+		}
+		opts.Chart = chartNew
+	}
+	return nil
+}
+
+func ReplaceStorageClass(valuesYaml string) (string, error) {
+	// find the storage class name in the options
+	re, _ := regexp.Compile(`storageClass:.*\n`)
+	storageConfig := re.FindString(valuesYaml)
+	if storageConfig == "" {
+		return "", fmt.Errorf("storageClass is required in  values_yaml config")
+	}
+
+	// replace the storage class name with default storage class name
+	valuesYaml = re.ReplaceAllString(valuesYaml, fmt.Sprintf("storageClass: %s\n", JenkinsPvDefaultStorageClassName))
+	log.Debugf("new values_yaml whose storage class is replaced by default : %s\n", valuesYaml)
+
+	return valuesYaml, nil
 }

--- a/internal/pkg/plugin/jenkins/validate.go
+++ b/internal/pkg/plugin/jenkins/validate.go
@@ -15,7 +15,7 @@ func validate(opts *Options) []error {
 		return errs
 	}
 
-	// if dev mode, replace the storage class name with default storage class which is auto created with hostpath type.
+	// if dev mode, replace the StorageClass name with default StorageClass which is auto created with hostpath type.
 	if opts.TestEnv {
 		chartNew := opts.Chart
 		var err error
@@ -29,16 +29,16 @@ func validate(opts *Options) []error {
 }
 
 func ReplaceStorageClass(valuesYaml string) (string, error) {
-	// find the storage class name in the options
+	// find the StorageClass name in the options
 	re, _ := regexp.Compile(`storageClass:.*\n`)
 	storageConfig := re.FindString(valuesYaml)
 	if storageConfig == "" {
 		return "", fmt.Errorf("storageClass is required in  values_yaml config")
 	}
 
-	// replace the storage class name with default storage class name
+	// replace the StorageClass name with default StorageClass name
 	valuesYaml = re.ReplaceAllString(valuesYaml, fmt.Sprintf("storageClass: %s\n", JenkinsPvDefaultStorageClassName))
-	log.Debugf("new values_yaml whose storage class is replaced by default : %s\n", valuesYaml)
+	log.Debugf("new values_yaml whose StorageClass is replaced by default : %s\n", valuesYaml)
 
 	return valuesYaml, nil
 }

--- a/internal/pkg/plugin/jenkins/validate_test.go
+++ b/internal/pkg/plugin/jenkins/validate_test.go
@@ -1,0 +1,55 @@
+package jenkins_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/devstream-io/devstream/internal/pkg/plugin/jenkins"
+)
+
+var _ = Describe("Validate", func() {
+
+	Describe("test storage class name replacement", func() {
+		Context("when storage class name is provided", func() {
+			It("storage class should be replaced successfully", func() {
+				valuesYaml := `
+persistence:
+            storageClass: custom-storage-class
+          serviceAccount:
+            create: false
+            name: jenkins
+          # nodePort, 30000 - 32767
+          nodePort: 32000
+          annotations: {}
+`
+				valuesYaml, err := jenkins.ReplaceStorageClass(valuesYaml)
+
+				Expect(err).To(BeNil())
+				Expect(valuesYaml).To(Equal(`
+persistence:
+            storageClass: jenkins-pv
+          serviceAccount:
+            create: false
+            name: jenkins
+          # nodePort, 30000 - 32767
+          nodePort: 32000
+          annotations: {}
+`))
+			})
+		})
+	})
+
+	Context("when storage class name is not provided", func() {
+		valuesYaml := `
+persistence:
+          serviceAccount:
+            create: false
+            name: jenkins
+          # nodePort, 30000 - 32767
+          nodePort: 32000
+          annotations: {}
+`
+		_, err := jenkins.ReplaceStorageClass(valuesYaml)
+		Expect(err).NotTo(BeNil())
+	})
+})

--- a/internal/pkg/plugin/jenkins/validate_test.go
+++ b/internal/pkg/plugin/jenkins/validate_test.go
@@ -9,9 +9,9 @@ import (
 
 var _ = Describe("Validate", func() {
 
-	Describe("test storage class name replacement", func() {
-		Context("when storage class name is provided", func() {
-			It("storage class should be replaced successfully", func() {
+	Describe("test StorageClass name replacement", func() {
+		Context("when StorageClass name is provided", func() {
+			It("StorageClass should be replaced successfully", func() {
 				valuesYaml := `
 persistence:
             storageClass: custom-storage-class
@@ -39,7 +39,7 @@ persistence:
 		})
 	})
 
-	Context("when storage class name is not provided", func() {
+	Context("when StorageClass name is not provided", func() {
 		valuesYaml := `
 persistence:
           serviceAccount:

--- a/internal/pkg/show/config/plugins/jenkins.yaml
+++ b/internal/pkg/show/config/plugins/jenkins.yaml
@@ -7,6 +7,9 @@ tools:
     dependsOn: [ ]
     # options for the plugin
     options:
+      # if true, the plugin will use hostpath to create a pv named `jenkins-pv`
+      # and you should create the volumes directory manually, see plugin doc for details.
+      test_env: false
       # need to create the namespace or not, default: false
       create_namespace: false
       # Helm repo information
@@ -29,10 +32,15 @@ tools:
         timeout: 5m
         # whether to perform a CRD upgrade during installation
         upgradeCRDs: true
-        # custom configuration (Optional). You can refer to [Jenkins values.yaml](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml)
+        # custom configuration. You can refer to [Jenkins values.yaml](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml)
         values_yaml: |
           persistence:
+            # for prod env: the existent storageClass, please change it
+            # for test env: just ignore it, but don't remove it
             storageClass: jenkins-pv
           serviceAccount:
             create: false
             name: jenkins
+          controller:
+            serviceType: NodePort
+            nodePort: 32000


### PR DESCRIPTION
## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description

1. support test mod and prod mode meanwhile.
* test: auto-create PV named `jenkins-pv` and use host path
* prod: user can customize `storageClass`
2. use NodePort to expose service.
3. support `nodePort` config customize.
4. show Jenkins URL and tell user how to get the password of user admin
5. docs improved.

## Related Issues
#758 

## New Behavior (screenshots if needed)

### 1. dtm apply
 ./dtm apply -f jenkins.yaml -y
2022-06-27 20:48:26 ℹ [INFO]  Apply started.
2022-06-27 20:48:26 ℹ [INFO]  Got Backend from config: local
2022-06-27 20:48:26 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-06-27 20:48:27 ℹ [INFO]  Using local backend. State file: devstream.state.
2022-06-27 20:48:27 ℹ [INFO]  Tool (jenkins/default) found in config but doesn't exist in the state, will be created.
2022-06-27 20:48:27 ℹ [INFO]  Start executing the plan.
2022-06-27 20:48:27 ℹ [INFO]  Changes count: 1.
2022-06-27 20:48:27 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-06-27 20:48:27 ℹ [INFO]  Processing: (jenkins/default) -> Create ...
2022-06-27 20:48:27 ℹ [INFO]  Test environment is enabled. Please ensure you have created the directories correctly under the guide of plugin doc.
2022-06-27 20:48:27 !! [ERROR]  Failed to create PersistentVolume < jenkins-pv >: persistentvolumes "jenkins-pv" already exists.
2022-06-27 20:48:27 ℹ [INFO]  The resource PersistentVolume is already exists.
2022-06-27 20:48:28 ℹ [INFO]  Creating or updating helm chart ...
2022/06/27 20:48:31 creating 11 resource(s)
2022/06/27 20:48:31 beginning wait for 11 resources with timeout of 5m0s
2022/06/27 20:48:31 StatefulSet is not ready: jenkins/dev-jenkins. 0 out of 1 expected pods are ready
2022/06/27 20:48:33 StatefulSet is not ready: jenkins/dev-jenkins. 0 out of 1 expected pods are ready
...
...
2022/06/27 20:51:47 StatefulSet is not ready: jenkins/dev-jenkins. 0 out of 1 expected pods are ready
2022/06/27 20:51:49 StatefulSet is not ready: jenkins/dev-jenkins. 0 out of 1 expected pods are ready
2022/06/27 20:51:51 StatefulSet is not ready: jenkins/dev-jenkins. 0 out of 1 expected pods are ready
2022/06/27 20:51:53 release installed successfully: dev/jenkins-4.1.11
2022-06-27 20:51:53 ℹ [INFO]  Here is how to get the password of the admin user:
2022-06-27 20:51:53 ℹ [INFO]  kubectl exec --namespace jenkins -it svc/dev-jenkins -c jenkins -- /bin/cat /run/secrets/additional/chart-admin-password && echo
2022-06-27 20:51:53 ℹ [INFO]  Jenkins url:http://172.18.0.2:32000/login

2022-06-27 20:51:53 ✔ [SUCCESS]  Tool (jenkins/default) Create done.
2022-06-27 20:51:53 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-06-27 20:51:53 ✔ [SUCCESS]  All plugins applied successfully.
2022-06-27 20:51:53 ✔ [SUCCESS]  Apply finished.

(Note: `persistentvolumes "jenkins-pv" already exists.` can be ignored.)

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/36830265/175946799-736b6736-a8be-4e7b-83ab-f450b00904b0.png">

<img width="908" alt="image" src="https://user-images.githubusercontent.com/36830265/175946938-8d36b12d-5450-4f2e-8aab-1ecfe26d5636.png">

<img width="810" alt="image" src="https://user-images.githubusercontent.com/36830265/175947211-a6d12a65-2c76-40a5-b302-21e457a4d44e.png">


### 2. dtm delete

❯ ./dtm delete -f jenkins.yaml -y
2022-06-27 20:59:19 ℹ [INFO]  Delete started.
2022-06-27 20:59:19 ℹ [INFO]  Got Backend from config: local
2022-06-27 20:59:19 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-06-27 20:59:19 ℹ [INFO]  Using local backend. State file: devstream.state.
2022-06-27 20:59:19 ℹ [INFO]  Tool (jenkins/default) will be deleted.
2022-06-27 20:59:19 ℹ [INFO]  Start executing the plan.
2022-06-27 20:59:19 ℹ [INFO]  Changes count: 1.
2022-06-27 20:59:19 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-06-27 20:59:19 ℹ [INFO]  Processing: (jenkins/default) -> Delete ...
2022-06-27 20:59:21 ℹ [INFO]  Uninstalling jenkins helm chart ...
2022/06/27 20:59:21 uninstall: Deleting dev
2022/06/27 20:59:23 Starting delete for "dev-jenkins" Service
2022/06/27 20:59:23 Starting delete for "dev-jenkins-agent" Service
2022/06/27 20:59:23 Starting delete for "dev-jenkins" StatefulSet
2022/06/27 20:59:23 Starting delete for "dev-jenkins-watch-configmaps" RoleBinding
2022/06/27 20:59:23 Starting delete for "dev-jenkins-schedule-agents" RoleBinding
2022/06/27 20:59:23 Starting delete for "dev-jenkins-schedule-agents" Role
2022/06/27 20:59:23 Starting delete for "dev-jenkins-casc-reload" Role
2022/06/27 20:59:23 Starting delete for "dev-jenkins" PersistentVolumeClaim
2022/06/27 20:59:23 Starting delete for "dev-jenkins-jenkins-jcasc-config" ConfigMap
2022/06/27 20:59:23 Starting delete for "dev-jenkins" ConfigMap
2022/06/27 20:59:23 Starting delete for "dev-jenkins" Secret
2022/06/27 20:59:23 purge requested for dev
2022/06/27 20:59:23 release uninstalled, response: &{0x14000631a40 }
2022-06-27 20:59:23 ⚠ [WARN]  

NOTICE!!!
The PersistentVolume jenkins-pv is NOT been deleted.
You can execute the "kubectl delete pv jenkins-pv" to delete it manually.The local data directory /Users/lhp/data/jenkins-volumes is also NOT been deleted.You can delete it manually.

2022-06-27 20:59:23 ℹ [INFO]  Prepare to delete 'jenkins_default' from States.
2022-06-27 20:59:23 ✔ [SUCCESS]  Tool (jenkins/default) delete done.
2022-06-27 20:59:23 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-06-27 20:59:23 ✔ [SUCCESS]  All plugins deleted successfully.
2022-06-27 20:59:23 ✔ [SUCCESS]  Delete finished.
