### PR TITLE
ci: license scanning for cncf compliance

### DIFF
--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -1,0 +1,14 @@
+name: license check by FOSS
+on: [pull_request]
+
+jobs:
+  fossa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: fossa-contrib/fossa-action@v1
+        with:
+          # https://docs.fossa.com/docs/api-reference#push-only-api-token
+          fossa-api-key: c03fe407c7aa56b90b7dac1ae1868dd0


### PR DESCRIPTION
Signed-off-by: KeHaoKH <hao.ke@merico.dev>

## Description

license scanning for CNCF compliance

The corresponding triggered scan actions are here:  https://github.com/devstream-io/devstream/runs/7077653652?check_suite_focus=true

