### PR TITLE
feat: create a one-click script for quick start

### DIFF
--- a/docs/quickstart.zh.md
+++ b/docs/quickstart.zh.md
@@ -1,29 +1,27 @@
 # 快速开始
 
-如果你还没有观看我们的demo，你可以在[文档站点的主页](./index.md)观看。
+如果你还没有观看我们的demo，可以前往[文档站点的主页](./index.md)观看。
 
-## 1 下载 DevStream (`dtm`)
+## 1 下载 DevStream (`dtm`) 与配置文件
 
-根据你的实际环境从 [DevStream Releases](https://github.com/devstream-io/devstream/releases) 下载合适的 `dtm` 版本。
+注意：dtm 仅支持 Linux 与 macOS。
 
-> 记得将二进制文件重命名为 `dtm`，这样用起来更简单。比如：`mv dtm-darwin-arm64 dtm`。
-
-> 一旦下载完成，你就可以将 dtm 文件放到任何目录下运行了。当然更加建议你将 dtm 加到 PATH 下(比如 `/usr/local/bin`)。
-
-## 2 准备一个配置文件
-
-开始之前：这是一个DevStream配置的例子：[examples/quickstart.yaml](https://github.com/devstream-io/devstream/blob/main/examples/quickstart.yaml) 。
-记得打开这个配置文件，把里面所有的 `FULL_UPPER_CASE_STRINGS`（比如说 `YOUR_GITHUB_USERNAME` ）修改成你自己的。注意每一项的含义，并确保它是你要的。对于其他插件，请查看我们的 [文档](https://docs.devstream.io) 中的"插件"部分，以了解详细用法。
-
-将 [examples/quickstart.yaml](https://raw.githubusercontent.com/devstream-io/devstream/main/examples/quickstart.yaml) 文件下载到你到工作目录下：
-
+进入你的工作目录，运行以下命令，自动下载最新的 `dtm` 与配置文件：
 ```shell
-curl -o quickstart.yaml https://raw.githubusercontent.com/devstream-io/devstream/main/examples/quickstart.yaml
+sh -c "$(curl -fsSL https://github.com/devstream-io/devstream/blob/main/hack/quick-start/quickstart.sh)"
 ```
 
-然后相应的修改配置文件中的内容。
+此命令执行完毕，你的工作区将会多出两个文件：dtm 与 quickstart.yaml。
 
-比如我的 GitHub 用户名是 "IronCore864", 然后我的 Dockerhub 用户名是 "ironcore864"，这样我就可以运行：
+建议你将 dtm 加到 PATH 下(比如 `/usr/local/bin`)。
+
+## 2 修改配置文件内容与设置环境变量
+
+打开 quickstart.yaml，把里面所有的`全大写字母的标识`（如 `YOUR_GITHUB_USERNAME` ）修改成你自己的。对于其他插件，请查看我们的 [文档](https://docs.devstream.io) 中的"插件"部分，以了解详细用法。
+
+将 [examples/quickstart.yaml](https://raw.githubusercontent.com/devstream-io/devstream/main/examples/quickstart.yaml) 文件下载到你的工作目录下：
+
+比如我的 GitHub 用户名是 "IronCore864", Dockerhub 用户名是 "ironcore864"，可以运行：
 
 ```shell
 sed -i.bak "s/YOUR_GITHUB_USERNAME_CASE_SENSITIVE/IronCore864/g" quickstart.yaml
@@ -78,7 +76,7 @@ dtm init -f quickstart.yaml
 
 如果你没有用` -f `参数指定配置文件，它将尝试使用默认值，即当前目录下的 `config.yaml` 。
 
-`dtm`将对比 `Config`、`State` 和 `Resource`，决定是否需要 `Create`、`Update` 或 `Delete`。更多信息请阅读我们的 [核心概念](https://docs.devstream.io/en/latest/core-concepts/core-concepts/) 文档。
+`dtm` 将对比 `Config`、`State` 和 `Resource`，决定是否需要 `Create`、`Update` 或 `Delete`。更多信息请阅读我们的 [核心概念](https://docs.devstream.io/en/latest/core-concepts/core-concepts/) 文档。
 
 上面的命令在实际执行改变之前会要求你确认。如果不需要确认就应用 `Config`（就像 `apt-get -y update` ），请运行：
 
@@ -190,3 +188,7 @@ Enter a value (Default is n): y
 2022-03-04 12:10:42 ✔ [SUCCESS]  All plugins destroyed successfully.
 2022-03-04 12:10:42 ✔ [SUCCESS]  Destroy finished.
 ```
+
+### 8 了解更多
+
+DevStream 能实现的远不止这些，更多强大功能，请前往[最佳实践](https://docs.devstream.io/en/latest/best-practices/gitops.zh/)。

--- a/hack/quick-start/quickstart.sh
+++ b/hack/quick-start/quickstart.sh
@@ -1,0 +1,60 @@
+function init() {
+  if [ "$(uname)" == "Darwin" ];then
+    HOST_OS="darwin"
+  elif [ "$(uname)" == "Linux" ];then
+    HOST_OS="linux"
+  else
+    echo "Support Darwin/Linux OS only"
+    exit 1
+  fi
+
+  if [ "$(arch)" == "amd64" ];then
+    HOST_ARCH="amd64"
+  elif [ "$(arch)" == "arm64" ];then
+    HOST_ARCH="arm64"
+  else
+    echo "Support amd64/arm64 CPU arch only"
+    exit 1
+  fi
+
+  echo "Got OS type: ${HOST_OS} and CPU arch: ${HOST_ARCH}"
+}
+
+function getLatestReleaseVersion() {
+  latestVersion=$(curl -s https://api.github.com/repos/devstream-io/devstream/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  if [ -z "$latestVersion" ]; then
+    echo "Failed to get latest release version"
+    exit 1
+  fi
+  echo "Latest dtm release version: ${latestVersion}"
+}
+
+function downloadDtm() {
+  # 1. download the release and rename it to "dtm"
+  # 2. count the download count of the release
+  fullReleaseUrl="https://devstream.gateway.scarf.sh/releases/$latestVersion/dtm-$HOST_OS-$HOST_ARCH"
+  echo "Downloading dtm from: $fullReleaseUrl"
+  # use -L to follow redirects
+  curl -L -o dtm $fullReleaseUrl
+  echo "dtm downloaded completed"
+
+  # grant execution rights
+  chmod +x dtm
+}
+
+function downloadQuickStartConfig() {
+  curl -o quickstart.yaml https://raw.githubusercontent.com/devstream-io/devstream/main/examples/quickstart.yaml
+}
+
+function showDtmHelp() {
+  echo ""
+  # show dtm help and double check the download is success
+  ./dtm help
+}
+
+init
+getLatestReleaseVersion
+downloadDtm
+downloadQuickStartConfig
+showDtmHelp
+

--- a/hack/quick-start/quickstart.sh
+++ b/hack/quick-start/quickstart.sh
@@ -26,7 +26,7 @@ function getLatestReleaseVersion() {
     echo "Failed to get latest release version"
     exit 1
   fi
-  echo "Latest dtm release version: ${latestVersion}"
+  echo "Latest dtm release version: ${latestVersion}\n"
 }
 
 function downloadDtm() {
@@ -36,14 +36,16 @@ function downloadDtm() {
   echo "Downloading dtm from: $fullReleaseUrl"
   # use -L to follow redirects
   curl -L -o dtm $fullReleaseUrl
-  echo "dtm downloaded completed"
+  echo "dtm downloaded completed\n"
 
   # grant execution rights
   chmod +x dtm
 }
 
 function downloadQuickStartConfig() {
-  curl -o quickstart.yaml https://raw.githubusercontent.com/devstream-io/devstream/main/examples/quickstart.yaml
+  # config file is small so we use -s to ignore the output
+  curl -s -o quickstart.yaml https://raw.githubusercontent.com/devstream-io/devstream/main/examples/quickstart.yaml
+  echo "quickstart.yaml downloaded completed"
 }
 
 function showDtmHelp() {


### PR DESCRIPTION
Signed-off-by: Bird <aflybird0@gmail.com>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description

Create a one-click script for quick start. Execute these steps in one script:

1. Download latest dtm release according to OS and CPU arch.
2. Rename release to "dtm".
3. Download quickstart.yaml.
4. Show dtm help.

## Related Issues
close #769 

## New Behavior (screenshots if needed)

on macOS:

❯ sh quickstart.sh

```shell
Got OS type: darwin and CPU arch: arm64
Latest dtm release version: v0.7.0
Downloading dtm from: https://devstream.gateway.scarf.sh/releases/v0.7.0/dtm-darwin-arm64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
100 22.2M  100 22.2M    0     0  3386k      0  0:00:06  0:00:06 --:--:-- 5728k
dtm downloaded completed
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   986  100   986    0     0   1146      0 --:--:-- --:--:-- --:--:--  1157

DevStream is an open-source DevOps toolchain manager

######                 #####
#     # ###### #    # #     # ##### #####  ######   ##   #    #
#     # #      #    # #         #   #    # #       #  #  ##  ##
#     # #####  #    #  #####    #   #    # #####  #    # # ## #
#     # #      #    #       #   #   #####  #      ###### #    #
#     # #       #  #  #     #   #   #   #  #      #    # #    #
######  ######   ##    #####    #   #    # ###### #    # #    #

Usage:
  dtm [command]

Available Commands:
  apply       Create or update DevOps tools according to DevStream configuration file
  completion  Generate the autocompletion script for dtm for the specified shell
  delete      Delete DevOps tools according to DevStream configuration file
  destroy     Destroy DevOps tools deployment according to DevStream configuration file & state file
  develop     Develop is used for develop a new plugin
  help        Help about any command
  init        Download needed plugins according to the config file
  list        This command only supports listing plugins now.
  show        Show is used to print some useful information
  verify      Verify DevOps tools according to DevStream config file and state
  version     Print the version number of DevStream

Flags:
      --debug   debug level log
  -h, --help    help for dtm

Use "dtm [command] --help" for more information about a command.
```
<img width="717" alt="image" src="https://user-images.githubusercontent.com/36830265/176315165-71db6452-a8fa-4887-b306-d3090eb70147.png">
