### PR TITLE
feat(ci): add broken links check CI

### DIFF
--- a/.github/workflows/link-pr.yml
+++ b/.github/workflows/link-pr.yml
@@ -1,0 +1,48 @@
+name: Links When PR
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**.md'
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download Exclude Path
+        run: |
+            curl https://raw.githubusercontent.com/devstream-io/devstream/main/.lycheeignore --output .lycheeignore
+
+      # replace site base url to build MkDocs in local
+      - name: Replace Base URL
+        run: |
+          sed -i 's|https://docs.devstream.io|http://localhost|g' mkdocs.yml
+
+      - name: Build MkDocs
+        uses: Tiryoh/actions-mkdocs@v0
+        with:
+          mkdocs_version: 'latest'
+          requirements: 'docs/requirements.txt'
+          configfile: 'mkdocs.yml'
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.5.0
+        with:
+          fail: true
+            # For parameter description, see https://github.com/lycheeverse/lychee#commandline-parameters
+            # -E, --exclude-all-private    Exclude all private IPs from checking.
+            # -v, --verbose                Verbose program output
+            # -i, --insecure               Proceed for server connections considered insecure (invalid TLS)
+            # -n, --no-progress            Do not show progress bar.
+            # -t, --timeout <timeout>      Website timeout in seconds from connect to response finished [default:20]
+            # --max-concurrency <max-concurrency>    Maximum number of concurrent network requests [default: 128]
+            # -a --accept <accept>                      Comma-separated list of accepted status codes for valid links
+
+            # ./site the MkDocs site directory to check
+            # ./*.md all markdown files in the root directory
+          args: -E -v -i -n -t 45 --max-concurrency 32 -a 429,401 -- ./site;*.md
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -1,0 +1,55 @@
+name: Links
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 8 * * *"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download Exclude Path
+        run: |
+          curl https://raw.githubusercontent.com/devstream-io/devstream/main/.lycheeignore --output .lycheeignore
+
+      # replace site base url to build MkDocs in local
+      - name: Replace Base URL
+        run: |
+          sed -i 's|https://docs.devstream.io|http://localhost|g' mkdocs.yml
+
+      - name: Build MkDocs
+        uses: Tiryoh/actions-mkdocs@v0
+        with:
+            mkdocs_version: 'latest'
+            requirements: 'docs/requirements.txt'
+            configfile: 'mkdocs.yml'
+
+      - name: Check Links
+        uses: lycheeverse/lychee-action@v1.5.0
+        with:
+          # For parameter description, see https://github.com/lycheeverse/lychee#commandline-parameters
+          # -E, --exclude-all-private    Exclude all private IPs from checking.
+          # -v, --verbose                Verbose program output
+          # -i, --insecure               Proceed for server connections considered insecure (invalid TLS)
+          # -n, --no-progress            Do not show progress bar.
+          # -t, --timeout <timeout>      Website timeout in seconds from connect to response finished [default:20]
+          # --max-concurrency <max-concurrency>    Maximum number of concurrent network requests [default: 128]
+          # -a --accept <accept>                      Comma-separated list of accepted status codes for valid links
+
+          # ./site the MkDocs site directory to check
+          # ./*.md all markdown files in the root directory
+          args: -E -v -i -n -t 45 --max-concurrency 32 -a 429,401 -- ./site;*.md
+          output: out.md
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+#      - name: Create Issue From File
+#        uses: peter-evans/create-issue-from-file@v3
+#        with:
+#          title: Broken Link Detected
+#          content-filepath: out.md
+##          assignees: aFlyBird0

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,10 @@
+https://github.com/.*/pull/[0-9]+.*
+https://github.com/.*/issues/[0-9]+.*
+https://fonts.gstatic.com/
+.*mkdocs\.yaml\*\.md
+.*foo.*
+.*bar.*
+.*xxx.*
+https://id.atlassian.net
+https://JIRA_ID.atlassian.net
+https://vault-0.vault-internal:8201/


### PR DESCRIPTION
## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description

* When/How to trigger
    * 8:30 every day
    * markdown file being changed during pr
* Scope
  * MkDocs generated sites
  * markdown files in the root of the project
* Steps
   1. local build MkDocs
   2. Use [lychee-action](https://github.com/lycheeverse/lychee-action) to perform the check
* Next actions: 
  * goto GitHub Actions to see detailed errors. 
  * If there are broken links, the issue will be automatically sent and the specified document owner will be assigned if there are broken links (currently not enabled, wait for all existing broken links to be fixed before enabling).

## Related Issues
close #792 

## New Behavior (screenshots if needed)

example: https://github.com/aFlyBird0/devstream-fork/actions/runs/2590054005

A screenshot of the example above:
<img width="1050" alt="image" src="https://user-images.githubusercontent.com/36830265/176693704-1c450f14-fdc7-48ae-a82a-d7406ff31a59.png">

