### PR TITLE
fix: architecture determination in script

### DIFF
--- a/hack/e2e/e2e-up.sh
+++ b/hack/e2e/e2e-up.sh
@@ -28,9 +28,9 @@ function init() {
     exit 1
   fi
 
-  if [ "$(arch)" == "amd64" ];then
+  if [ "$(uname -m)" == "amd64" ] || [ "$(uname -m)" == "x86_64" ];then
     HOST_ARCH="amd64"
-  elif [ "$(arch)" == "arm64" ];then
+  elif [ "$(uname -m)" == "arm64" ];then
     HOST_ARCH="arm64"
   else
     echo "Support amd64/arm64 CPU arch only"

--- a/hack/quick-start/quickstart.sh
+++ b/hack/quick-start/quickstart.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 function init() {
   if [ "$(uname)" == "Darwin" ];then
     HOST_OS="darwin"
@@ -8,9 +10,9 @@ function init() {
     exit 1
   fi
 
-  if [ "$(arch)" == "amd64" ];then
+  if [ "$(uname -m)" == "amd64" ] || [ "$(uname -m)" == "x86_64" ];then
     HOST_ARCH="amd64"
-  elif [ "$(arch)" == "arm64" ];then
+  elif [ "$(uname -m)" == "arm64" ];then
     HOST_ARCH="arm64"
   else
     echo "Support amd64/arm64 CPU arch only"


### PR DESCRIPTION
Signed-off-by: hxcGit <houxc_mail@163.com>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [ ] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [ ] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->
Use `uname -m` to view the machine architecture rather than `arch` and treate `x86_64` as `amd64`.
## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->
https://github.com/devstream-io/devstream/issues/796

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->
#### In Linux machine
<img width="762" alt="image" src="https://user-images.githubusercontent.com/60642406/176861311-1f379f13-bbd9-466b-bf25-1565836f62b5.png">

#### In MacOS
<img width="862" alt="image" src="https://user-images.githubusercontent.com/60642406/176861464-beb99901-9ee6-4542-be77-ffa3712f5235.png">

