### PR TITLE
feat: pkg/util/log Enhancement (sub task of pkg/util Enhancement #833)

### DIFF
--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -9,10 +9,15 @@ func TestLog(t *testing.T) {
 	Info("nice to meet you ", "log")
 	Warn("nice to meet you ", "log")
 	Success("nice to meet you ", "log")
+	Error("nice to meet you ", "log")
+	// Fatal("nice to meet you ", "log") // fatal calling os.exit will cause test case exit with 1
+	Separator("nice to meet you ", "log")
 
 	Debugf("nice to meet you %s", "log")
 	Infof("nice to meet you %s", "log")
 	Warnf("nice to meet you %s", "log")
 	Successf("nice to meet you %s", "log")
-
+	Errorf("nice to meet you %s", "log")
+	// Fatalf("nice to meet you %s", "log")
+	Separatorf("nice to meet you %s", "log")
 }

--- a/pkg/util/log/logwrapper.go
+++ b/pkg/util/log/logwrapper.go
@@ -50,7 +50,10 @@ func (m *CliLoggerFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	newLog := fmt.Sprintf("%s %s %s %s\n", timestamp, m.prefix, m.formatLevelName, entry.Message)
 
-	b.WriteString(newLog)
+	_, err := b.WriteString(newLog)
+	if err != nil {
+		return nil, err
+	}
 	return b.Bytes(), nil
 }
 
@@ -74,7 +77,7 @@ func (m *CliLoggerFormatter) levelPrintRender() {
 		m.formatLevelName = color.BgRed.Render(ERROR)
 		m.prefix = color.Red.Render(normal.Error)
 	case "fatal":
-		m.level = logrus.InfoLevel
+		m.level = logrus.FatalLevel
 		m.formatLevelName = color.BgRed.Render(FATAL)
 		m.prefix = color.Red.Render(normal.Fatal)
 	case "success":
@@ -102,7 +105,10 @@ func (s *SeparatorFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		color.Blue.Render(INFO),
 		color.Blue.Render(fmt.Sprintf("%s %s %s", "-------------------- [ ", entry.Message, " ] --------------------")))
 
-	b.WriteString(newLog)
+	_, err := b.WriteString(newLog)
+	if err != nil {
+		return nil, err
+	}
 	return b.Bytes(), nil
 }
 

--- a/pkg/util/log/logwrapper_test.go
+++ b/pkg/util/log/logwrapper_test.go
@@ -1,0 +1,224 @@
+package log
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/gookit/color.v1"
+)
+
+func TestCliLoggerFormatter_Format(t *testing.T) {
+	emptyEntry := &logrus.Entry{}
+	entry := &logrus.Entry{
+		Level:   logrus.ErrorLevel,
+		Message: "hi log",
+	}
+	emptyFormatter := &CliLoggerFormatter{}
+	formatter := &CliLoggerFormatter{
+		prefix:   "pp",
+		showType: "error",
+	}
+	tests := []struct {
+		name      string
+		formatter *CliLoggerFormatter
+		entry     *logrus.Entry
+		want      []byte
+		wantErr   bool
+	}{
+		{"base", emptyFormatter, emptyEntry, createBufferForCliLoggerFormatter(t, emptyFormatter, emptyEntry).Bytes(), false},
+		{"base debug", formatter, entry, createBufferForCliLoggerFormatter2(t, formatter, entry).Bytes(), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// logrus.SetLevel(logrus.DebugLevel)
+			got, err := tt.formatter.Format(tt.entry)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CliLoggerFormatter.Format() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CliLoggerFormatter.Format() = \n%v, want \n%v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCliLoggerFormatter_levelPrintRender(t *testing.T) {
+	tests := []struct {
+		name      string
+		formatter *CliLoggerFormatter
+		want      *CliLoggerFormatter
+	}{
+		// TODO: Add test cases.
+		{"base", &CliLoggerFormatter{}, &CliLoggerFormatter{}},
+		{"base debug",
+			&CliLoggerFormatter{showType: "debug"},
+			&CliLoggerFormatter{
+				level:           logrus.DebugLevel,
+				showType:        "debug",
+				formatLevelName: color.Blue.Render(DEBUG),
+				prefix:          color.Blue.Render(normal.Debug)},
+		},
+		{"base info",
+			&CliLoggerFormatter{showType: "info"},
+			&CliLoggerFormatter{
+				level:           logrus.InfoLevel,
+				showType:        "info",
+				formatLevelName: color.FgLightBlue.Render(INFO),
+				prefix:          color.FgLightBlue.Render(normal.Info)},
+		},
+		{"base warn",
+			&CliLoggerFormatter{showType: "warn"},
+			&CliLoggerFormatter{
+				level:           logrus.WarnLevel,
+				showType:        "warn",
+				formatLevelName: color.Yellow.Render(WARN),
+				prefix:          color.Yellow.Render(normal.Warn)},
+		},
+		{"base error",
+			&CliLoggerFormatter{showType: "error"},
+			&CliLoggerFormatter{
+				level:           logrus.ErrorLevel,
+				showType:        "error",
+				formatLevelName: color.BgRed.Render(ERROR),
+				prefix:          color.Red.Render(normal.Error)},
+		},
+		{"base fatal",
+			&CliLoggerFormatter{showType: "fatal"},
+			&CliLoggerFormatter{
+				level:           logrus.FatalLevel,
+				showType:        "fatal",
+				formatLevelName: color.BgRed.Render(FATAL),
+				prefix:          color.Red.Render(normal.Fatal)},
+		},
+		{"base success",
+			&CliLoggerFormatter{showType: "success"},
+			&CliLoggerFormatter{
+				level:           logrus.InfoLevel,
+				showType:        "success",
+				formatLevelName: color.Green.Render(SUCCESS),
+				prefix:          color.Green.Render(normal.Success)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.formatter.levelPrintRender()
+			if !reflect.DeepEqual(tt.formatter, tt.want) {
+				t.Errorf("levelPrintRender = \n%v", tt.formatter)
+				t.Errorf("want = \n%v", tt.want)
+			}
+		})
+	}
+}
+
+func TestSeparatorFormatter_Format(t *testing.T) {
+	b := createBufferForSeparatorFormatter(t)
+	tests := []struct {
+		name    string
+		s       *SeparatorFormatter
+		entry   *logrus.Entry
+		want    []byte
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{"base", &SeparatorFormatter{}, &logrus.Entry{}, b.Bytes(), false},
+		{"base Entry with buffer", &SeparatorFormatter{}, &logrus.Entry{Buffer: &bytes.Buffer{}}, b.Bytes(), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SeparatorFormatter{}
+			got, err := s.Format(tt.entry)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SeparatorFormatter.Format() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SeparatorFormatter.Format() = \n%v", string(got))
+				t.Errorf("want = \n%v", tt.want)
+			}
+		})
+	}
+}
+
+func createBufferForSeparatorFormatter(t *testing.T) *bytes.Buffer {
+	var b *bytes.Buffer = &bytes.Buffer{}
+	entry := &logrus.Entry{}
+	timestamp := entry.Time.Format("2006-01-02 15:04:05")
+	newLog := fmt.Sprintf("%s %s %s %s\n",
+		timestamp,
+		color.Blue.Render(normal.Info),
+		color.Blue.Render(INFO),
+		color.Blue.Render(fmt.Sprintf("%s %s %s", "-------------------- [ ", entry.Message, " ] --------------------")))
+
+	_, err := b.WriteString(newLog)
+	if err != nil {
+		t.Error(err)
+		return nil
+	}
+	return b
+}
+
+func createBufferForCliLoggerFormatter(t *testing.T, m *CliLoggerFormatter, entry *logrus.Entry) *bytes.Buffer {
+	var b *bytes.Buffer = &bytes.Buffer{}
+	m.levelPrintRender()
+
+	timestamp := entry.Time.Format("2006-01-02 15:04:05")
+
+	newLog := fmt.Sprintf("%s %s %s %s\n", timestamp, m.prefix, m.formatLevelName, entry.Message)
+
+	_, err := b.WriteString(newLog)
+	if err != nil {
+		t.Error(err)
+		return nil
+	}
+	return b
+}
+
+func createBufferForCliLoggerFormatter2(t *testing.T, m *CliLoggerFormatter, entry *logrus.Entry) *bytes.Buffer {
+	var b *bytes.Buffer = &bytes.Buffer{}
+	m.levelPrintRender()
+
+	timestamp := entry.Time.Format("2006-01-02 15:04:05")
+
+	entry.Message = addCallStackIgnoreLogrus(entry.Message)
+
+	newLog := fmt.Sprintf("%s %s %s %s\n", timestamp, m.prefix, m.formatLevelName, entry.Message)
+
+	_, err := b.WriteString(newLog)
+	if err != nil {
+		t.Error(err)
+		return nil
+	}
+	return b
+}
+
+func Test_addCallStackIgnoreLogrus(t *testing.T) {
+	rawMsg := "hi log"
+	tests := []struct {
+		name       string
+		rawMessage string
+		want       string
+	}{
+		// TODO: Add test cases.
+		{"base", rawMsg, wantMsgOfAddCallStackIgnoreLogrus(rawMsg)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := addCallStackIgnoreLogrus(tt.rawMessage); got != tt.want {
+				t.Errorf("addCallStackIgnoreLogrus() = \n%v, \nwant = %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func wantMsgOfAddCallStackIgnoreLogrus(stackMessage string) string {
+	retMsg := stackMessage
+	i := 10
+	_, file, line, _ := runtime.Caller(i)
+	retMsg = retMsg + "\n  -- " + file + fmt.Sprintf(" %d", line)
+	return retMsg
+}

--- a/pkg/util/log/symbol_test.go
+++ b/pkg/util/log/symbol_test.go
@@ -1,0 +1,40 @@
+package log
+
+import "testing"
+
+func TestSymbols_String(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		symbols Symbols
+		want    string
+	}{
+		// TODO: Add test cases.
+		{"base", Symbols{}, "Debug:  Info:  Success:  Warning:  Error:  Fatal: "},
+		{"base", Symbols{Debug: "Debug"}, "Debug: Debug Info:  Success:  Warning:  Error:  Fatal: "},
+		{"base", Symbols{
+			Debug:   Symbol("λ"),
+			Info:    Symbol("ℹ"),
+			Success: Symbol("✔"),
+			Warning: Symbol("⚠"),
+			Error:   Symbol("!!"),
+			Fatal:   Symbol("✖"),
+		}, "Debug: λ Info: ℹ Success: ✔ Warning: ⚠ Error: !! Fatal: ✖"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Symbols{
+				Debug:   tt.symbols.Debug,
+				Info:    tt.symbols.Info,
+				Warning: tt.symbols.Warning,
+				Warn:    tt.symbols.Warn,
+				Error:   tt.symbols.Error,
+				Fatal:   tt.symbols.Fatal,
+				Success: tt.symbols.Success,
+			}
+			if got := s.String(); got != tt.want {
+				t.Errorf("\nSymbols.String() = %v, \nwant = %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: xian-jie.shen <327411586@qq.com>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
trying to resolve:
- handle necessary err of file writing operation 
- add test case and hit a high coverage

## Related Issues
see https://github.com/devstream-io/devstream/issues/833 for the details

## New Behavior (screenshots if needed)
- handle necessary err of file writing operation

![image](https://user-images.githubusercontent.com/6358406/179384119-b76dc7ae-ddf3-4434-93e4-9ebaa7031b67.png)

- ut coverage
```sh
[going@dev log]$ go test . -coverprofile=./coverage.out -timeout=10m -short -v
=== RUN   TestLog
2022-07-17 12:31:57 ℹ [INFO]  nice to meet you log
2022-07-17 12:31:57 ⚠ [WARN]  nice to meet you log
2022-07-17 12:31:57 ✔ [SUCCESS]  nice to meet you log
2022-07-17 12:31:57 !! [ERROR]  nice to meet you log
2022-07-17 12:31:57 ℹ [INFO]  -------------------- [  nice to meet you log  ] --------------------
2022-07-17 12:31:57 ℹ [INFO]  nice to meet you log
2022-07-17 12:31:57 ⚠ [WARN]  nice to meet you log
2022-07-17 12:31:57 ✔ [SUCCESS]  nice to meet you log
2022-07-17 12:31:57 !! [ERROR]  nice to meet you log
2022-07-17 12:31:57 ℹ [INFO]  -------------------- [  nice to meet you log  ] --------------------
--- PASS: TestLog (0.00s)
=== RUN   TestCliLoggerFormatter_Format
=== RUN   TestCliLoggerFormatter_Format/base
=== RUN   TestCliLoggerFormatter_Format/base_debug
--- PASS: TestCliLoggerFormatter_Format (0.00s)
    --- PASS: TestCliLoggerFormatter_Format/base (0.00s)
    --- PASS: TestCliLoggerFormatter_Format/base_debug (0.00s)
=== RUN   TestCliLoggerFormatter_levelPrintRender
=== RUN   TestCliLoggerFormatter_levelPrintRender/base
=== RUN   TestCliLoggerFormatter_levelPrintRender/base_debug
=== RUN   TestCliLoggerFormatter_levelPrintRender/base_info
=== RUN   TestCliLoggerFormatter_levelPrintRender/base_warn
=== RUN   TestCliLoggerFormatter_levelPrintRender/base_error
=== RUN   TestCliLoggerFormatter_levelPrintRender/base_fatal
=== RUN   TestCliLoggerFormatter_levelPrintRender/base_success
--- PASS: TestCliLoggerFormatter_levelPrintRender (0.00s)
    --- PASS: TestCliLoggerFormatter_levelPrintRender/base (0.00s)
    --- PASS: TestCliLoggerFormatter_levelPrintRender/base_debug (0.00s)
    --- PASS: TestCliLoggerFormatter_levelPrintRender/base_info (0.00s)
    --- PASS: TestCliLoggerFormatter_levelPrintRender/base_warn (0.00s)
    --- PASS: TestCliLoggerFormatter_levelPrintRender/base_error (0.00s)
    --- PASS: TestCliLoggerFormatter_levelPrintRender/base_fatal (0.00s)
    --- PASS: TestCliLoggerFormatter_levelPrintRender/base_success (0.00s)
=== RUN   TestSeparatorFormatter_Format
=== RUN   TestSeparatorFormatter_Format/base
=== RUN   TestSeparatorFormatter_Format/base_Entry_with_buffer
--- PASS: TestSeparatorFormatter_Format (0.00s)
    --- PASS: TestSeparatorFormatter_Format/base (0.00s)
    --- PASS: TestSeparatorFormatter_Format/base_Entry_with_buffer (0.00s)
=== RUN   Test_addCallStackIgnoreLogrus
=== RUN   Test_addCallStackIgnoreLogrus/base
--- PASS: Test_addCallStackIgnoreLogrus (0.00s)
    --- PASS: Test_addCallStackIgnoreLogrus/base (0.00s)
=== RUN   TestSymbols_String
=== RUN   TestSymbols_String/base
=== RUN   TestSymbols_String/base#01
=== RUN   TestSymbols_String/base#02
--- PASS: TestSymbols_String (0.00s)
    --- PASS: TestSymbols_String/base (0.00s)
    --- PASS: TestSymbols_String/base#01 (0.00s)
    --- PASS: TestSymbols_String/base#02 (0.00s)
PASS
coverage: 91.1% of statements
ok      github.com/devstream-io/devstream/pkg/util/log  0.007s  coverage: 91.1% of statements
```
