### PR TITLE
ci: let the concurrency of e2e workflow be 1

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -22,6 +22,10 @@ env:
   TRELLO_API_KEY: ${{ secrets.E2E_TRELLO_API_KEY }}
   TRELLO_TOKEN: ${{ secrets.E2E_TRELLO_TOKEN }}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   e2e-test:
     # permissions for id and other


### PR DESCRIPTION
Signed-off-by: KeHaoKH <hao.ke@merico.dev>

## Pre-Checklist

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
let the concurrency of e2e workflow be 1.

Otherwise, if the concurrency of the workflow will be greater than 1, resulting in e.g. a GitHub repo just being deleted and created again, this will cause the previous workflow to fail in the cleanup step.

## New Behavior (screenshots if needed)
As you can see from the screenshot below from a test on my personal repository, two e2e actions were triggered by consecutive commits, but one of the later actions was pended

![image](https://user-images.githubusercontent.com/103085894/180028702-c9e964fd-0180-497a-bfa0-9380a022d649.png)

![image](https://user-images.githubusercontent.com/103085894/180028774-1924ea70-3499-4dd3-831e-73fb68a81490.png)


