### PR TITLE
fix: issue template error with documentation type

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -14,9 +14,6 @@ body:
   id: terms
   attributes:
     label: Please read the documents below.
-    description: |
-      1. [Creating a Documentation for DevStream](https://docs.devstream.io/en/latest/development/mkdocs/)
-      2. [Document Translation(Chinese only)](https://docs.devstream.io/en/latest/development/translation.zh/)
     options:
-      - label: I've read the documents above. (If you want to submit a document type contribution.)
+      - label: I've read the document [Creating a Documentation for DevStream](https://docs.devstream.io/en/latest/development/mkdocs/) and [Document Translation(Chinese only)](https://docs.devstream.io/en/latest/development/translation.zh/). (If you want to submit a document type contribution.)
         required: false


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [ ] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

Fix issue template error with documentation type

## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->

N/A

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->

Old behavior: 

![image](https://user-images.githubusercontent.com/18692628/182601426-e7d2f031-eca9-4870-97cf-3f76fdc88d6b.png)

The document list don't be shown at the issue page.
