### PR TITLE
fix: fail to create github webhook automatically

### DIFF
--- a/internal/pkg/plugin/jenkinsgithub/jcasc.go
+++ b/internal/pkg/plugin/jenkinsgithub/jcasc.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"fmt"
 	"text/template"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
@@ -74,6 +75,10 @@ func applyJCasC(namespace, chartReleaseName, configName, fileContent string) err
 	}
 
 	log.Debugf("Created configmap %+v", configMapRes)
+
+	// wait for the config map and the sidecar to be ready
+	// TODO(aFlyBird0): read JCasC to judge if JCasC is ready
+	time.Sleep(time.Second * 3)
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Bird <aflybird0@gmail.com>

## Description
I created a new build in #921 to automatically create a Jenkins Job triggered by GitHub.

This pr is here to fix it.

Although the code looks weird, in the short term, it's the easiest and quickest way to fix it.

After a lot of troubleshooting, here's why I couldn't automatically generate the webhook

The first step is to create a ConfigMap to generate JCasC, which has a setting `manageWebhooks: true` to automatically create a webhook for the GitHub repo when you create a job, and the second step is to create a Jenkins job.

The problem is that after creating the ConfigMap in step 1, you need to poll the ConfigMap via sidecar to convert it to JCasC, so the `manageWebhooks` configuration takes effect after the job is created.

We just need to make sure that we create the job after the configuration takes effect. The current strategy is to sleep for 3 seconds.

Of course, the best strategy is to poll the latest JCasC and create the job as soon as the configuration takes effect, but considering that we need to spend time testing the project near the release, and that Jenkins installation itself is a very time-consuming task, it is acceptable to wait three seconds longer than that.

## Related Issues
#921

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->
