### PR TITLE
ci: use `.lycheeignore` in current pr rather than `main` branch

### DIFF
--- a/.github/workflows/link-pr.yml
+++ b/.github/workflows/link-pr.yml
@@ -5,16 +5,13 @@ on:
     branches: [ main ]
     paths:
       - '**.md'
+      - '.lycheeignore'
 
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Download Exclude Path
-        run: |
-            curl https://raw.githubusercontent.com/devstream-io/devstream/main/.lycheeignore --output .lycheeignore
 
       # replace site base url to build MkDocs in local
       - name: Replace Base URL

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,7 +1,8 @@
 https://github.com/.*/pull/[0-9]+.*
 https://github.com/.*/issues/[0-9]+.*
 https://fonts.gstatic.com/
-.*${.*}.*
+.*\$\{.*\}.*
+.*ssh.*
 .*foo.*
 .*bar.*
 .*xxx.*


### PR DESCRIPTION
Signed-off-by: Bird <aflybird0@gmail.com>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [ ] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description

Solved the problem where the `.lycheeignore` file was modified during pr but did not take effect immediately.

<img width="993" alt="image" src="https://user-images.githubusercontent.com/36830265/182997336-6f803edd-457a-4221-b307-436a918f2b07.png">

`checkout` actions will pull the newest code so there is no need to download files again.


## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->
