### PR TITLE
Feat: The Plugin GitLab CE Enhancement

### DIFF
--- a/docs/plugins/gitlab-ce-docker.md
+++ b/docs/plugins/gitlab-ce-docker.md
@@ -17,7 +17,7 @@ Note:
 - get the password of user `root` in gitlab-ce-docker
 
 ```shell
-sudo docker exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
+docker exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
 ```
 
 - clone code

--- a/docs/plugins/gitlab-ce-docker.md
+++ b/docs/plugins/gitlab-ce-docker.md
@@ -4,7 +4,7 @@ This plugin installs [GitLab](https://about.gitlab.com/) CE(Community Edition) o
 
 _NOTICE: currently, this plugin support Linux only._
 
-## 背景知识
+## Background
 
 GitLab officially provides an image [gitlab-ce](https://registry.hub.docker.com/r/gitlab/gitlab-ce). We can use this image to start a container:
 
@@ -21,8 +21,9 @@ docker run --detach \
   gitlab/gitlab-ce:rc
 ```
 
-The variable $GITLAB_HOME here pointing to the directory where the configuration, logs, and data files will reside.
-We could set this variable by the `export` command:
+The variable `$GITLAB_HOME` here pointing to the directory where the configuration, logs, and data files will reside.
+
+We can set this variable by the `export` command:
 
 ```shell
 export GITLAB_HOME=/srv/gitlab
@@ -36,7 +37,7 @@ The GitLab container uses host mounted volumes to store persistent data:
 | `$GITLAB_HOME/logs`   | `/var/log/gitlab` | For storing logs                           |
 | `$GITLAB_HOME/config` | `/etc/gitlab`     | For storing the GitLab configuration files |
 
-So, we can customize some configurations as follows:
+So, we can customize the following configurations:
 
 1. hostname
 2. host port
@@ -46,14 +47,14 @@ So, we can customize some configurations as follows:
 ## Configuration
 
 Note: 
-1. the user you are using must be `root` or is in `docker` group;
-2. `https` isn't supported now.
+1. the user you are using must be `root` or in the `docker` group;
+2. `https` isn't supported for now.
 
 ```yaml
 --8<-- "gitlab-ce-docker.yaml"
 ```
 
-## Some Commands May Help You
+## Some Commands That May Help
 
 - clone code
 

--- a/docs/plugins/gitlab-ce-docker.md
+++ b/docs/plugins/gitlab-ce-docker.md
@@ -2,7 +2,46 @@
 
 This plugin installs [GitLab](https://about.gitlab.com/) CE(Community Edition) on Docker.
 
-## Usage
+## 背景知识
+
+GitLab officially provides an image [gitlab-ce](https://registry.hub.docker.com/r/gitlab/gitlab-ce). We can use this image to start a container:
+
+```shell
+docker run --detach \
+  --hostname gitlab.example.com \
+  --publish 443:443 --publish 80:80 --publish 22:22 \
+  --name gitlab \
+  --restart always \
+  --volume $GITLAB_HOME/config:/etc/gitlab \
+  --volume $GITLAB_HOME/logs:/var/log/gitlab \
+  --volume $GITLAB_HOME/data:/var/opt/gitlab \
+  --shm-size 256m \
+  gitlab/gitlab-ce:latest
+```
+
+The variable $GITLAB_HOME here pointing to the directory where the configuration, logs, and data files will reside.
+We could set this variable by the `export` command:
+
+```shell
+export GITLAB_HOME=/srv/gitlab
+```
+
+The GitLab container uses host mounted volumes to store persistent data:
+
+| Local location        |Container location |                    Usage                   |
+| --------------------- | ----------------- | ------------------------------------------ |
+| `$GITLAB_HOME/data`   | `/var/opt/gitlab` | For storing application data               |
+| `$GITLAB_HOME/logs`   | `/var/log/gitlab` | For storing logs                           |
+| `$GITLAB_HOME/config` | `/etc/gitlab`     | For storing the GitLab configuration files |
+
+So, we can customize some configurations as follows:
+
+1. hostname
+2. host port
+3. persistent data path
+4. docker image tag
+
+## Configuration
 
 Note: 
 1. the user you are using must be `root` or is in `docker` group;
@@ -13,12 +52,6 @@ Note:
 ```
 
 ## Some Commands May Help You
-
-- get the password of user `root` in gitlab-ce-docker
-
-```shell
-docker exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
-```
 
 - clone code
 

--- a/docs/plugins/gitlab-ce-docker.md
+++ b/docs/plugins/gitlab-ce-docker.md
@@ -2,6 +2,8 @@
 
 This plugin installs [GitLab](https://about.gitlab.com/) CE(Community Edition) on Docker.
 
+_NOTICE: currently, this plugin support Linux only._
+
 ## 背景知识
 
 GitLab officially provides an image [gitlab-ce](https://registry.hub.docker.com/r/gitlab/gitlab-ce). We can use this image to start a container:
@@ -16,7 +18,7 @@ docker run --detach \
   --volume $GITLAB_HOME/logs:/var/log/gitlab \
   --volume $GITLAB_HOME/data:/var/opt/gitlab \
   --shm-size 256m \
-  gitlab/gitlab-ce:latest
+  gitlab/gitlab-ce:rc
 ```
 
 The variable $GITLAB_HOME here pointing to the directory where the configuration, logs, and data files will reside.

--- a/docs/plugins/gitlab-ce-docker.zh.md
+++ b/docs/plugins/gitlab-ce-docker.zh.md
@@ -2,7 +2,45 @@
 
 这个插件用于以 Docker 的方式安装 [GitLab](https://about.gitlab.com/) CE（社区版）。
 
-## 用法
+## 背景知识
+
+GitLab 官方提供了 [gitlab-ce](https://registry.hub.docker.com/r/gitlab/gitlab-ce) 镜像，通过这个镜像我们可以实现类似这样的命令来启动一个 GitLab 容器：
+
+```shell
+docker run --detach \
+  --hostname gitlab.example.com \
+  --publish 443:443 --publish 80:80 --publish 22:22 \
+  --name gitlab \
+  --restart always \
+  --volume $GITLAB_HOME/config:/etc/gitlab \
+  --volume $GITLAB_HOME/logs:/var/log/gitlab \
+  --volume $GITLAB_HOME/data:/var/opt/gitlab \
+  --shm-size 256m \
+  gitlab/gitlab-ce:latest
+```
+
+其中 $GITLAB_HOME 表示的是本地存储卷路径，比如我们可以通过 export 命令来设置这个变量：
+
+```shell
+export GITLAB_HOME=/srv/gitlab
+```
+
+在上述命令中，我们可以看到这个容器使用了3个存储卷，含义分别如下：
+
+| 本地路径               | 容器内路径          | 用途               |
+| --------------------- | ----------------- | ----------------- |
+| `$GITLAB_HOME/data`   | `/var/opt/gitlab` | 保存应用数据        |
+| `$GITLAB_HOME/logs`   | `/var/log/gitlab` | 保存日志            |
+| `$GITLAB_HOME/config` | `/etc/gitlab`     | 保存 GitLab 配置文件 |
+
+在此基础上，我们可以自定义如下一些配置：
+
+1. hostname
+2. 本机端口
+3. 存储卷路径
+4. 镜像版本
+
+## 配置
 
 注意: 
 1. 你使用的用户必须是 `root` 或者在 `docker` 用户组里；
@@ -13,12 +51,6 @@
 ```
 
 ## 一些可能有用的命令
-
-- 查看 gitlab 的 root 用户的密码:
-
-```shell
-docker exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
-```
 
 - 克隆项目
 

--- a/docs/plugins/gitlab-ce-docker.zh.md
+++ b/docs/plugins/gitlab-ce-docker.zh.md
@@ -2,6 +2,8 @@
 
 这个插件用于以 Docker 的方式安装 [GitLab](https://about.gitlab.com/) CE（社区版）。
 
+_注意：目前本插件仅支持 Linux。_
+
 ## 背景知识
 
 GitLab 官方提供了 [gitlab-ce](https://registry.hub.docker.com/r/gitlab/gitlab-ce) 镜像，通过这个镜像我们可以实现类似这样的命令来启动一个 GitLab 容器：
@@ -16,7 +18,7 @@ docker run --detach \
   --volume $GITLAB_HOME/logs:/var/log/gitlab \
   --volume $GITLAB_HOME/data:/var/opt/gitlab \
   --shm-size 256m \
-  gitlab/gitlab-ce:latest
+  gitlab/gitlab-ce:rc
 ```
 
 其中 $GITLAB_HOME 表示的是本地存储卷路径，比如我们可以通过 export 命令来设置这个变量：

--- a/docs/plugins/gitlab-ce-docker.zh.md
+++ b/docs/plugins/gitlab-ce-docker.zh.md
@@ -17,7 +17,7 @@
 - 查看 gitlab 的 root 用户的密码:
 
 ```shell
-sudo docker exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
+docker exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
 ```
 
 - 克隆项目

--- a/internal/pkg/plugin/gitlabcedocker/create.go
+++ b/internal/pkg/plugin/gitlabcedocker/create.go
@@ -13,7 +13,7 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	gitlabURL = opts.getGitLabURL()
+	opts.setGitLabURL()
 
 	// 2. config install operations
 	runner := &plugininstaller.Runner{

--- a/internal/pkg/plugin/gitlabcedocker/create.go
+++ b/internal/pkg/plugin/gitlabcedocker/create.go
@@ -8,12 +8,10 @@ import (
 
 func Create(options map[string]interface{}) (map[string]interface{}, error) {
 	// 1. create config and pre-handle operations
-	opts, err := preHandleOptions(options)
+	opts, err := validateAndDefault(options)
 	if err != nil {
 		return nil, err
 	}
-
-	opts.setGitLabURL()
 
 	// 2. config install operations
 	runner := &plugininstaller.Runner{
@@ -22,7 +20,7 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		},
 		ExecuteOperations: []plugininstaller.BaseOperation{
 			dockerInstaller.InstallOrUpdate,
-			showGitLabURL,
+			showHelpMsg,
 		},
 		TerminateOperations: []plugininstaller.BaseOperation{
 			dockerInstaller.HandleRunFailure,

--- a/internal/pkg/plugin/gitlabcedocker/delete.go
+++ b/internal/pkg/plugin/gitlabcedocker/delete.go
@@ -7,7 +7,7 @@ import (
 
 func Delete(options map[string]interface{}) (bool, error) {
 	// 1. create config and pre-handle operations
-	opts, err := preHandleOptions(options)
+	opts, err := validateAndDefault(options)
 	if err != nil {
 		return false, err
 	}

--- a/internal/pkg/plugin/gitlabcedocker/gitlabcedocker.go
+++ b/internal/pkg/plugin/gitlabcedocker/gitlabcedocker.go
@@ -1,8 +1,18 @@
 package gitlabcedocker
 
 const (
+	defaultHostname       = "gitlab.example.com"
+	defaultGitlabHome     = "/srv/gitlab"
+	defaultSSHPort        = 22
+	defaultHTTPPort       = 80
+	defaultHTTPSPort      = 443
+	defaultImageTag       = "rc"
 	gitlabImageName       = "gitlab/gitlab-ce"
-	defaultGitlabImageTag = "rc"
 	gitlabContainerName   = "gitlab"
 	dockerRunShmSizeParam = "--shm-size 256m"
+)
+
+var (
+	rmDataAfterDelete        = false
+	defaultRMDataAfterDelete = &rmDataAfterDelete
 )

--- a/internal/pkg/plugin/gitlabcedocker/gitlabcedocker.go
+++ b/internal/pkg/plugin/gitlabcedocker/gitlabcedocker.go
@@ -1,28 +1,8 @@
 package gitlabcedocker
 
-import (
-	"fmt"
-
-	"github.com/devstream-io/devstream/internal/pkg/plugininstaller"
-	"github.com/devstream-io/devstream/pkg/util/log"
-)
-
 const (
 	gitlabImageName       = "gitlab/gitlab-ce"
-	defaultImageTag       = "rc"
+	defaultGitlabImageTag = "rc"
 	gitlabContainerName   = "gitlab"
 	dockerRunShmSizeParam = "--shm-size 256m"
 )
-
-// gitlabURL is the access URL of GitLab.
-var gitlabURL string
-
-func (opts *Options) getGitLabURL() string {
-	return fmt.Sprintf("http://%s:%d", opts.Hostname, opts.HTTPPort)
-}
-
-func showGitLabURL(options plugininstaller.RawOptions) error {
-	log.Infof("GitLab access URL: %s", gitlabURL)
-
-	return nil
-}

--- a/internal/pkg/plugin/gitlabcedocker/gitlabcedocker.go
+++ b/internal/pkg/plugin/gitlabcedocker/gitlabcedocker.go
@@ -1,5 +1,7 @@
 package gitlabcedocker
 
+import "github.com/devstream-io/devstream/pkg/util/types"
+
 const (
 	defaultHostname       = "gitlab.example.com"
 	defaultGitlabHome     = "/srv/gitlab"
@@ -13,6 +15,5 @@ const (
 )
 
 var (
-	rmDataAfterDelete        = false
-	defaultRMDataAfterDelete = &rmDataAfterDelete
+	defaultRMDataAfterDelete = types.Bool(false)
 )

--- a/internal/pkg/plugin/gitlabcedocker/options.go
+++ b/internal/pkg/plugin/gitlabcedocker/options.go
@@ -12,14 +12,38 @@ import (
 
 // Options is the struct for configurations of the gitlab-ce-docker plugin.
 type Options struct {
+	Hostname string `validate:"hostname" mapstructure:"hostname"`
 	// GitLab home directory, we assume the path set by user is always correct.
-	GitLabHome        string `validate:"required" mapstructure:"gitlab_home"`
-	Hostname          string `validate:"required,hostname" mapstructure:"hostname"`
-	SSHPort           uint   `validate:"required" mapstructure:"ssh_port"`
-	HTTPPort          uint   `validate:"required" mapstructure:"http_port"`
-	HTTPSPort         uint   `validate:"required" mapstructure:"https_port"`
-	RmDataAfterDelete bool   `mapstructure:"rm_data_after_delete"`
+	GitLabHome        string `mapstructure:"gitlab_home"`
+	SSHPort           uint   `mapstructure:"ssh_port"`
+	HTTPPort          uint   `mapstructure:"http_port"`
+	HTTPSPort         uint   `mapstructure:"https_port"`
+	RmDataAfterDelete *bool  `mapstructure:"rm_data_after_delete"`
 	ImageTag          string `mapstructure:"image_tag"`
+}
+
+func (opts *Options) Defaults() {
+	if opts.Hostname == "" {
+		opts.Hostname = defaultHostname
+	}
+	if opts.GitLabHome == "" {
+		opts.GitLabHome = defaultGitlabHome
+	}
+	if opts.SSHPort == 0 {
+		opts.SSHPort = defaultSSHPort
+	}
+	if opts.HTTPPort == 0 {
+		opts.HTTPPort = defaultHTTPPort
+	}
+	if opts.HTTPSPort == 0 {
+		opts.HTTPSPort = defaultHTTPSPort
+	}
+	if opts.RmDataAfterDelete == nil {
+		opts.RmDataAfterDelete = defaultRMDataAfterDelete
+	}
+	if opts.ImageTag == "" {
+		opts.ImageTag = defaultImageTag
+	}
 }
 
 // gitlabURL is the access URL of GitLab.

--- a/internal/pkg/plugin/gitlabcedocker/options.go
+++ b/internal/pkg/plugin/gitlabcedocker/options.go
@@ -1,10 +1,13 @@
 package gitlabcedocker
 
 import (
+	"fmt"
 	"path/filepath"
 
+	"github.com/devstream-io/devstream/internal/pkg/plugininstaller"
 	dockerInstaller "github.com/devstream-io/devstream/internal/pkg/plugininstaller/docker"
 	"github.com/devstream-io/devstream/pkg/util/docker"
+	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
 // Options is the struct for configurations of the gitlab-ce-docker plugin.
@@ -19,25 +22,40 @@ type Options struct {
 	ImageTag          string `mapstructure:"image_tag"`
 }
 
-func buildDockerOptions(opts *Options) *dockerInstaller.Options {
-	dockerOpts := &dockerInstaller.Options{}
-	dockerOpts.RmDataAfterDelete = opts.RmDataAfterDelete
-	dockerOpts.ImageName = gitlabImageName
-	dockerOpts.ImageTag = opts.ImageTag
-	dockerOpts.Hostname = opts.Hostname
-	dockerOpts.ContainerName = gitlabContainerName
-	dockerOpts.RestartAlways = true
+// gitlabURL is the access URL of GitLab.
+var gitlabURL string
 
+func (opts *Options) setGitLabURL() {
+	if gitlabURL != "" {
+		return
+	}
+	gitlabURL = fmt.Sprintf("http://%s:%d", opts.Hostname, opts.HTTPPort)
+}
+
+func showGitLabURL(options plugininstaller.RawOptions) error {
+	log.Infof("GitLab access URL: %s", gitlabURL)
+
+	return nil
+}
+
+func buildDockerOptions(opts *Options) *dockerInstaller.Options {
 	portPublishes := []docker.PortPublish{
 		{HostPort: opts.SSHPort, ContainerPort: 22},
 		{HostPort: opts.HTTPPort, ContainerPort: 80},
 		{HostPort: opts.HTTPSPort, ContainerPort: 443},
 	}
-	dockerOpts.PortPublishes = portPublishes
 
-	dockerOpts.Volumes = buildDockerVolumes(opts)
-
-	dockerOpts.RunParams = []string{dockerRunShmSizeParam}
+	dockerOpts := &dockerInstaller.Options{
+		RmDataAfterDelete: opts.RmDataAfterDelete,
+		ImageName:         gitlabImageName,
+		ImageTag:          opts.ImageTag,
+		Hostname:          opts.Hostname,
+		ContainerName:     gitlabContainerName,
+		RestartAlways:     true,
+		Volumes:           buildDockerVolumes(opts),
+		RunParams:         []string{dockerRunShmSizeParam},
+		PortPublishes:     portPublishes,
+	}
 
 	return dockerOpts
 }

--- a/internal/pkg/plugin/gitlabcedocker/options.go
+++ b/internal/pkg/plugin/gitlabcedocker/options.go
@@ -32,8 +32,9 @@ func (opts *Options) setGitLabURL() {
 	gitlabURL = fmt.Sprintf("http://%s:%d", opts.Hostname, opts.HTTPPort)
 }
 
-func showGitLabURL(options plugininstaller.RawOptions) error {
+func showHelpMsg(options plugininstaller.RawOptions) error {
 	log.Infof("GitLab access URL: %s", gitlabURL)
+	log.Infof("GitLab initial root password: execute the command -> docker exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password")
 
 	return nil
 }

--- a/internal/pkg/plugin/gitlabcedocker/options_test.go
+++ b/internal/pkg/plugin/gitlabcedocker/options_test.go
@@ -6,12 +6,12 @@ import (
 
 	dockerInstaller "github.com/devstream-io/devstream/internal/pkg/plugininstaller/docker"
 	"github.com/devstream-io/devstream/pkg/util/docker"
+	"github.com/devstream-io/devstream/pkg/util/types"
 )
 
 var _ = Describe("Options", func() {
 
 	var opts *Options
-	var rmDataAfterDelete = false
 	BeforeEach(func() {
 		opts = &Options{
 			GitLabHome:        "/srv/gitlab",
@@ -19,7 +19,7 @@ var _ = Describe("Options", func() {
 			SSHPort:           8122,
 			HTTPPort:          8180,
 			HTTPSPort:         8443,
-			RmDataAfterDelete: &rmDataAfterDelete,
+			RmDataAfterDelete: types.Bool(false),
 			ImageTag:          "rc",
 		}
 	})

--- a/internal/pkg/plugin/gitlabcedocker/options_test.go
+++ b/internal/pkg/plugin/gitlabcedocker/options_test.go
@@ -6,7 +6,6 @@ import (
 
 	dockerInstaller "github.com/devstream-io/devstream/internal/pkg/plugininstaller/docker"
 	"github.com/devstream-io/devstream/pkg/util/docker"
-	"github.com/devstream-io/devstream/pkg/util/types"
 )
 
 var _ = Describe("Options", func() {
@@ -19,7 +18,7 @@ var _ = Describe("Options", func() {
 			SSHPort:           8122,
 			HTTPPort:          8180,
 			HTTPSPort:         8443,
-			RmDataAfterDelete: types.Bool(false),
+			RmDataAfterDelete: nil,
 			ImageTag:          "rc",
 		}
 	})

--- a/internal/pkg/plugin/gitlabcedocker/options_test.go
+++ b/internal/pkg/plugin/gitlabcedocker/options_test.go
@@ -11,7 +11,7 @@ import (
 var _ = Describe("Options", func() {
 
 	var opts *Options
-
+	var rmDataAfterDelete = false
 	BeforeEach(func() {
 		opts = &Options{
 			GitLabHome:        "/srv/gitlab",
@@ -19,7 +19,7 @@ var _ = Describe("Options", func() {
 			SSHPort:           8122,
 			HTTPPort:          8180,
 			HTTPSPort:         8443,
-			RmDataAfterDelete: false,
+			RmDataAfterDelete: &rmDataAfterDelete,
 			ImageTag:          "rc",
 		}
 	})

--- a/internal/pkg/plugin/gitlabcedocker/read.go
+++ b/internal/pkg/plugin/gitlabcedocker/read.go
@@ -13,8 +13,6 @@ func Read(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	gitlabURL = opts.getGitLabURL()
-
 	// 2. config read operations
 	runner := &plugininstaller.Runner{
 		PreExecuteOperations: []plugininstaller.MutableOperation{

--- a/internal/pkg/plugin/gitlabcedocker/read.go
+++ b/internal/pkg/plugin/gitlabcedocker/read.go
@@ -8,7 +8,7 @@ import (
 
 func Read(options map[string]interface{}) (map[string]interface{}, error) {
 	// 1. create config and pre-handle operations
-	opts, err := preHandleOptions(options)
+	opts, err := validateAndDefault(options)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/plugin/gitlabcedocker/update.go
+++ b/internal/pkg/plugin/gitlabcedocker/update.go
@@ -8,12 +8,10 @@ import (
 
 func Update(options map[string]interface{}) (map[string]interface{}, error) {
 	// 1. create config and pre-handle operations
-	opts, err := preHandleOptions(options)
+	_, err := validateAndDefault(options)
 	if err != nil {
 		return nil, err
 	}
-
-	opts.setGitLabURL()
 
 	// 2. config install operations
 	runner := &plugininstaller.Runner{
@@ -22,7 +20,7 @@ func Update(options map[string]interface{}) (map[string]interface{}, error) {
 		},
 		ExecuteOperations: []plugininstaller.BaseOperation{
 			dockerInstaller.InstallOrUpdate,
-			showGitLabURL,
+			showHelpMsg,
 		},
 		GetStatusOperation: dockerInstaller.GetRunningState,
 	}

--- a/internal/pkg/plugin/gitlabcedocker/update.go
+++ b/internal/pkg/plugin/gitlabcedocker/update.go
@@ -13,7 +13,7 @@ func Update(options map[string]interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	gitlabURL = opts.getGitLabURL()
+	opts.setGitLabURL()
 
 	// 2. config install operations
 	runner := &plugininstaller.Runner{

--- a/internal/pkg/plugin/gitlabcedocker/validate.go
+++ b/internal/pkg/plugin/gitlabcedocker/validate.go
@@ -2,6 +2,7 @@ package gitlabcedocker
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/mitchellh/mapstructure"
@@ -29,6 +30,10 @@ func validateAndDefault(options map[string]interface{}) (*Options, error) {
 			log.Errorf("Options error: %s.", e)
 		}
 		return nil, fmt.Errorf("opts are illegal")
+	}
+
+	if err := os.MkdirAll(opts.GitLabHome, 0755); err != nil {
+		return nil, err
 	}
 
 	opts.setGitLabURL()

--- a/internal/pkg/plugin/gitlabcedocker/validate.go
+++ b/internal/pkg/plugin/gitlabcedocker/validate.go
@@ -27,7 +27,7 @@ func preHandleOptions(options map[string]interface{}) (*Options, error) {
 
 func defaults(opts *Options) {
 	if opts.ImageTag == "" {
-		opts.ImageTag = defaultImageTag
+		opts.ImageTag = defaultGitlabImageTag
 	}
 }
 

--- a/internal/pkg/plugin/gitlabcedocker/validate.go
+++ b/internal/pkg/plugin/gitlabcedocker/validate.go
@@ -10,41 +10,31 @@ import (
 	"github.com/devstream-io/devstream/pkg/util/validator"
 )
 
-func preHandleOptions(options map[string]interface{}) (*Options, error) {
+func validateAndDefault(options map[string]interface{}) (*Options, error) {
 	var opts *Options
 	if err := mapstructure.Decode(options, &opts); err != nil {
 		return nil, err
 	}
 
-	defaults(opts)
-
-	if err := validate(opts); err != nil {
-		return nil, err
-	}
-
-	return opts, nil
-}
-
-func defaults(opts *Options) {
-	if opts.ImageTag == "" {
-		opts.ImageTag = defaultGitlabImageTag
-	}
-}
-
-// validate validates the options provided by the core.
-func validate(options *Options) error {
+	// validate
 	errs := validator.Struct(options)
 	// volume directory must be absolute path
-	if !filepath.IsAbs(options.GitLabHome) {
+	if !filepath.IsAbs(opts.GitLabHome) {
 		errs = append(errs, fmt.Errorf("GitLabHome must be an absolute path"))
 	}
-
 	if len(errs) > 0 {
 		for _, e := range errs {
 			log.Errorf("Options error: %s.", e)
 		}
-		return fmt.Errorf("opts are illegal")
+		return nil, fmt.Errorf("opts are illegal")
 	}
 
-	return nil
+	// default
+	if opts.ImageTag == "" {
+		opts.ImageTag = defaultGitlabImageTag
+	}
+
+	opts.setGitLabURL()
+
+	return opts, nil
 }

--- a/internal/pkg/plugin/gitlabcedocker/validate.go
+++ b/internal/pkg/plugin/gitlabcedocker/validate.go
@@ -16,8 +16,10 @@ func validateAndDefault(options map[string]interface{}) (*Options, error) {
 		return nil, err
 	}
 
+	opts.Defaults()
+
 	// validate
-	errs := validator.Struct(options)
+	errs := validator.Struct(opts)
 	// volume directory must be absolute path
 	if !filepath.IsAbs(opts.GitLabHome) {
 		errs = append(errs, fmt.Errorf("GitLabHome must be an absolute path"))
@@ -27,11 +29,6 @@ func validateAndDefault(options map[string]interface{}) (*Options, error) {
 			log.Errorf("Options error: %s.", e)
 		}
 		return nil, fmt.Errorf("opts are illegal")
-	}
-
-	// default
-	if opts.ImageTag == "" {
-		opts.ImageTag = defaultGitlabImageTag
 	}
 
 	opts.setGitLabURL()

--- a/internal/pkg/plugininstaller/docker/installer.go
+++ b/internal/pkg/plugininstaller/docker/installer.go
@@ -125,7 +125,7 @@ func Delete(options plugininstaller.RawOptions) error {
 	}
 
 	// 4. remove the volume if it exists
-	if opts.RmDataAfterDelete {
+	if *opts.RmDataAfterDelete {
 		volumesDirFromOptions := opts.Volumes.ExtractHostPaths()
 		for _, err := range RemoveDirs(volumesDirFromOptions) {
 			log.Error(err)
@@ -150,7 +150,7 @@ func Delete(options plugininstaller.RawOptions) error {
 	}
 
 	// 8. check if the volume is removed
-	if opts.RmDataAfterDelete {
+	if *opts.RmDataAfterDelete {
 		volumesDirFromOptions := opts.Volumes.ExtractHostPaths()
 		for _, volume := range volumesDirFromOptions {
 			if exist := PathExist(volume); exist {

--- a/internal/pkg/plugininstaller/docker/installer.go
+++ b/internal/pkg/plugininstaller/docker/installer.go
@@ -118,11 +118,11 @@ func Delete(options plugininstaller.RawOptions) error {
 	}
 
 	// 3. remove the image if it exists
-	if ok := op.ImageIfExist(opts.GetImageNameWithTag()); ok {
-		if err := op.ImageRemove(opts.GetImageNameWithTag()); err != nil {
-			log.Errorf("failed to remove image %v: %v", opts.GetImageNameWithTag(), err)
-		}
-	}
+	//if ok := op.ImageIfExist(opts.GetImageNameWithTag()); ok {
+	//	if err := op.ImageRemove(opts.GetImageNameWithTag()); err != nil {
+	//		log.Errorf("failed to remove image %v: %v", opts.GetImageNameWithTag(), err)
+	//	}
+	//}
 
 	// 4. remove the volume if it exists
 	if *opts.RmDataAfterDelete {

--- a/internal/pkg/plugininstaller/docker/option.go
+++ b/internal/pkg/plugininstaller/docker/option.go
@@ -15,7 +15,7 @@ type Options struct {
 	ImageName         string `validate:"required"`
 	ImageTag          string `validate:"required"`
 	ContainerName     string `validate:"required"`
-	RmDataAfterDelete bool
+	RmDataAfterDelete *bool
 
 	RunParams     []string
 	Hostname      string

--- a/internal/pkg/plugininstaller/docker/option.go
+++ b/internal/pkg/plugininstaller/docker/option.go
@@ -11,20 +11,18 @@ import (
 	"github.com/devstream-io/devstream/pkg/util/validator"
 )
 
-type (
-	Options struct {
-		ImageName         string `validate:"required"`
-		ImageTag          string `validate:"required"`
-		ContainerName     string `validate:"required"`
-		RmDataAfterDelete bool
+type Options struct {
+	ImageName         string `validate:"required"`
+	ImageTag          string `validate:"required"`
+	ContainerName     string `validate:"required"`
+	RmDataAfterDelete bool
 
-		RunParams     []string
-		Hostname      string
-		PortPublishes []docker.PortPublish
-		Volumes       docker.Volumes
-		RestartAlways bool
-	}
-)
+	RunParams     []string
+	Hostname      string
+	PortPublishes []docker.PortPublish
+	Volumes       docker.Volumes
+	RestartAlways bool
+}
 
 // NewOptions create options by raw options
 func NewOptions(options plugininstaller.RawOptions) (Options, error) {
@@ -36,7 +34,7 @@ func NewOptions(options plugininstaller.RawOptions) (Options, error) {
 }
 
 func (opts *Options) GetImageNameWithTag() string {
-	return opts.ImageName + ":" + opts.ImageTag
+	return fmt.Sprintf("%s:%s", opts.ImageName, opts.ImageTag)
 }
 
 func (opts *Options) GetRunOpts() *docker.RunOptions {

--- a/internal/pkg/show/config/plugins/gitlab-ce-docker.yaml
+++ b/internal/pkg/show/config/plugins/gitlab-ce-docker.yaml
@@ -7,20 +7,22 @@ tools:
   dependsOn: [ ]
   # options for the plugin
   options:
-    # hostname for running docker
+    # hostname for running docker. (default: gitlab.example.com)
     hostname: gitlab.example.com
-    # the directory where you store docker volumes of gitlab
+    # pointing to the directory where the configuration, logs, and data files will reside.
+    # (default: /srv/gitlab)
     # 1. it should be a absolute path
-    # 2. once the tool is applied, it can't be changed
+    # 2. once the tool is installed, it can't be changed
     gitlab_home: /srv/gitlab
-    # ssh port exposed in the host machine
+    # ssh port exposed in the host machine. (default: 22)
     ssh_port: 22
-    # http port exposed in the host machine
+    # http port exposed in the host machine. (default: 80)
     http_port: 80
-    # https port exposed in the host machine
+    # https port exposed in the host machine.
+    # (default: 443)
     # todo: support https, reference: https://docs.gitlab.com/omnibus/settings/nginx.html#enable-https
     https_port: 443
-    # whether to delete the gitlab_home directory when the tool is removed
+    # whether to delete the gitlab_home directory when the tool is removed. (default: false)
     rm_data_after_delete: false
-    # gitlab-ce tag, default tag is rc
+    # gitlab-ce tag. (default: "rc")
     image_tag: "rc"


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

The Plugin GitLab CE Enhancement - Existing logic optimization.

I will refactor the Read() and Update() functions in the next pr.

@IronCore864 @aFlyBird0 PTAL.

## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->

N/A

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->

### 1. Apply/Delete with Minimal Configuration

- `config-gitlab.yaml` (ssh_port is set to avoid "address already in use" error)

```yaml
---
# core config
varFile: "" # If not empty, use the specified external variables config file
toolFile: "" # If not empty, use the specified external tools config file
state: # state config, backend can be local or s3
  backend: local
  options:
    stateFile: devstream.state

---
tools:
# name of the tool
- name: gitlab-ce-docker
  # id of the tool instance
  instanceID: default
  # format: name.instanceID; If specified, dtm will make sure the dependency is applied first before handling this tool.
  dependsOn: [ ]
  # options for the plugin
  options:
    ssh_port: 2022
```

- `./dtm apply -f config-gitlab.yaml`

```sh
2022-08-07 11:08:58 ℹ [INFO]  Apply started.
2022-08-07 11:08:58 ℹ [INFO]  Got Backend from config: local
2022-08-07 11:08:58 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-08-07 11:08:58 ℹ [INFO]  Using local backend. State file: devstream.state.
2022-08-07 11:08:58 ℹ [INFO]  Tool (gitlab-ce-docker/default) found in config but doesn't exist in the state, will be created.
Continue? [y/n]
Enter a value (Default is n): y

2022-08-07 11:09:00 ℹ [INFO]  Start executing the plan.
2022-08-07 11:09:00 ℹ [INFO]  Changes count: 1.
2022-08-07 11:09:00 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-08-07 11:09:00 ℹ [INFO]  Processing: (gitlab-ce-docker/default) -> Create ...
Stdout: rc: Pulling from gitlab/gitlab-ce
Stdout: Digest: sha256:5c1ce44973607ba2137babd27efcc8515e186360a36e7d920e55861d37747cfb
Stdout: Status: Image is up to date for gitlab/gitlab-ce:rc
Stdout: docker.io/gitlab/gitlab-ce:rc
2022-08-07 11:09:01 ℹ [INFO]  Running container as the name <gitlab>
Stdout: 1ed80d87cfcc532f78eecc5e4ca1629e718144c8a79a653e272760a13580d4b4
2022-08-07 11:09:01 ℹ [INFO]  GitLab access URL: http://gitlab.example.com:80
2022-08-07 11:09:01 ℹ [INFO]  GitLab initial root password: execute the command -> docker exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
2022-08-07 11:09:01 ✔ [SUCCESS]  Tool (gitlab-ce-docker/default) Create done.
2022-08-07 11:09:01 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-08-07 11:09:01 ✔ [SUCCESS]  All plugins applied successfully.
2022-08-07 11:09:01 ✔ [SUCCESS]  Apply finished.
```

- `docker ps`

```sh
CONTAINER ID   IMAGE                 COMMAND             CREATED          STATUS                    PORTS                                                                                                             NAMES
1ed80d87cfcc   gitlab/gitlab-ce:rc   "/assets/wrapper"   12 minutes ago   Up 12 minutes (healthy)   0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp, 0.0.0.0:2022->22/tcp, :::2022->22/tcp   gitlab
```

- `./dtm delete -f config-gitlab.yaml`

```sh
2022-08-07 11:28:27 ℹ [INFO]  Delete started.
2022-08-07 11:28:27 ℹ [INFO]  Got Backend from config: local
2022-08-07 11:28:27 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-08-07 11:28:27 ℹ [INFO]  Using local backend. State file: devstream.state.
2022-08-07 11:28:27 ℹ [INFO]  Tool (gitlab-ce-docker/default) will be deleted.
Continue? [y/n]
Enter a value (Default is n): y

2022-08-07 11:28:29 ℹ [INFO]  Start executing the plan.
2022-08-07 11:28:29 ℹ [INFO]  Changes count: 1.
2022-08-07 11:28:29 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-08-07 11:28:29 ℹ [INFO]  Processing: (gitlab-ce-docker/default) -> Delete ...
2022-08-07 11:28:29 ℹ [INFO]  Stopping container gitlab ...
Stdout: gitlab
2022-08-07 11:28:40 ℹ [INFO]  Removing container gitlab ...
Stdout: gitlab
2022-08-07 11:28:44 ℹ [INFO]  Prepare to delete 'gitlab-ce-docker_default' from States.
2022-08-07 11:28:44 ✔ [SUCCESS]  Tool (gitlab-ce-docker/default) delete done.
2022-08-07 11:28:44 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-08-07 11:28:44 ✔ [SUCCESS]  All plugins deleted successfully.
2022-08-07 11:28:44 ✔ [SUCCESS]  Delete finished.
```