### PR TITLE
feat: protect branch when init github repo

### DIFF
--- a/pkg/util/github/repo.go
+++ b/pkg/util/github/repo.go
@@ -168,7 +168,6 @@ func (c *Client) ProtectBranch(branch string) error {
 
 	_, _, err = c.Repositories.UpdateBranchProtection(c.Context, repo.GetOwner().GetLogin(), repo.GetName(), branch, req)
 	if err != nil {
-		log.Errorf("Protect branch failed: %s.", err)
 		return err
 	}
 

--- a/pkg/util/github/repo.go
+++ b/pkg/util/github/repo.go
@@ -163,7 +163,6 @@ func (c *Client) ProtectBranch(branch string) error {
 
 	repo, err := c.GetRepoDescription()
 	if err != nil {
-		log.Errorf("Get repo failed: %s.", err)
 		return err
 	}
 

--- a/pkg/util/github/repo_test.go
+++ b/pkg/util/github/repo_test.go
@@ -179,4 +179,30 @@ var _ = Describe("Repo", func() {
 			Expect(err).To(Succeed())
 		})
 	})
+
+	Context("ProtectBranch", func() {
+		BeforeEach(func() {
+			s.Reset()
+			s.SetAllowUnhandledRequests(true)
+		})
+		It("ProtectBranch with status 500", func() {
+			u := fmt.Sprintf("/repos/%v/%v", org, repo)
+			s.Reset()
+			s.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+			s.SetAllowUnhandledRequests(true)
+			s.RouteToHandler("GET", gh.BaseURLPath+u, func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, ``)
+			})
+			err := rightClient.ProtectBranch(mainBranch)
+			Expect(err).NotTo(Succeed())
+			Expect(err.Error()).To(ContainSubstring(strconv.Itoa(http.StatusInternalServerError)))
+		})
+		It("ProtectBranch with status 200", func() {
+			s.Reset()
+			s.SetAllowUnhandledRequests(true)
+			s.SetUnhandledRequestStatusCode(http.StatusOK)
+			err := rightClient.ProtectBranch(mainBranch)
+			Expect(err).To(Succeed())
+		})
+	})
 })


### PR DESCRIPTION
Signed-off-by: csonezp <csonezp@gmail.com>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
repo-scaffolding should protect the default main branch.

I'm not used to using ginkgo, so the test cases may not be well designed, If you find any problem please submit some suggestions

## Related Issues
Closes #963 

## New Behavior (screenshots if needed)
When use repo-scaffolding to create destination repo, protected the default branch.
