### PR TITLE
fix: change ioutil to os

### DIFF
--- a/pkg/util/git/commit_test.go
+++ b/pkg/util/git/commit_test.go
@@ -1,7 +1,6 @@
 package git_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -39,7 +38,7 @@ var _ = Describe("CommitInfo struct", func() {
 				dstPath = filepath.Join(tempDir, "dstFile")
 				testFile, err := os.CreateTemp(tempDir, "test")
 				Expect(err).Error().ShouldNot(HaveOccurred())
-				err = ioutil.WriteFile(testFile.Name(), fileContent, 0755)
+				err = os.WriteFile(testFile.Name(), fileContent, 0755)
 				Expect(err).Error().ShouldNot(HaveOccurred())
 				filePaths = []*git.GitFilePathInfo{
 					{
@@ -70,7 +69,7 @@ var _ = Describe("GenerateGitFileInfo func", func() {
 		tempFile, err := os.CreateTemp(tempDir, "test")
 		tempFileLoc = tempFile.Name()
 		Expect(err).Error().ShouldNot(HaveOccurred())
-		err = ioutil.WriteFile(tempFileLoc, testContent, 0755)
+		err = os.WriteFile(tempFileLoc, testContent, 0755)
 		Expect(err).Error().ShouldNot(HaveOccurred())
 	})
 	When("path not exist", func() {


### PR DESCRIPTION
Signed-off-by: iyear <ljyngup@gmail.com>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description

The latest version of golangci-lint checks for deprecated `ioutil` 
A file change was missed in #970

```
pkg/util/git/commit_test.go:4:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and t
hose implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
```

## Related Issues
N/A

