### PR TITLE
feat!: change default plugin dir

### DIFF
--- a/cmd/devstream/apply.go
+++ b/cmd/devstream/apply.go
@@ -30,7 +30,7 @@ func applyCMDFunc(cmd *cobra.Command, args []string) {
 
 func init() {
 	applyCMD.Flags().StringVarP(&configFile, configFlagName, "f", "config.yaml", "config file")
-	applyCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", pluginengine.DefaultPluginDir, "plugins directory")
+	applyCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", "", "plugins directory")
 	applyCMD.Flags().BoolVarP(&continueDirectly, "yes", "y", false, "apply directly without confirmation")
 
 	completion.FlagFilenameCompletion(applyCMD, configFlagName)

--- a/cmd/devstream/delete.go
+++ b/cmd/devstream/delete.go
@@ -33,7 +33,7 @@ func deleteCMDFunc(cmd *cobra.Command, args []string) {
 func init() {
 	deleteCMD.Flags().BoolVarP(&isForceDelete, "force", "", false, "force delete by config")
 	deleteCMD.Flags().StringVarP(&configFile, configFlagName, "f", "config.yaml", "config file")
-	deleteCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", pluginengine.DefaultPluginDir, "plugins directory")
+	deleteCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", "", "plugins directory")
 	deleteCMD.Flags().BoolVarP(&continueDirectly, "yes", "y", false, "delete directly without confirmation")
 
 	completion.FlagFilenameCompletion(deleteCMD, configFlagName)

--- a/cmd/devstream/init.go
+++ b/cmd/devstream/init.go
@@ -3,14 +3,13 @@ package main
 import (
 	"fmt"
 
-	"github.com/devstream-io/devstream/pkg/util/file"
-
 	"github.com/spf13/cobra"
 
 	"github.com/devstream-io/devstream/internal/pkg/completion"
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
 	"github.com/devstream-io/devstream/internal/pkg/pluginmanager"
 	"github.com/devstream-io/devstream/internal/pkg/version"
+	"github.com/devstream-io/devstream/pkg/util/file"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 

--- a/cmd/devstream/init.go
+++ b/cmd/devstream/init.go
@@ -3,11 +3,12 @@ package main
 import (
 	"fmt"
 
+	"github.com/devstream-io/devstream/pkg/util/file"
+
 	"github.com/spf13/cobra"
 
 	"github.com/devstream-io/devstream/internal/pkg/completion"
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
-	"github.com/devstream-io/devstream/internal/pkg/pluginengine"
 	"github.com/devstream-io/devstream/internal/pkg/pluginmanager"
 	"github.com/devstream-io/devstream/internal/pkg/version"
 	"github.com/devstream-io/devstream/pkg/util/log"
@@ -27,6 +28,8 @@ func initCMDFunc(_ *cobra.Command, _ []string) {
 		return
 	}
 
+	file.SetPluginDir(cfg.PluginDir)
+
 	if version.Dev {
 		log.Errorf("Dev version plugins can't be downloaded from the remote plugin repo; please run `make build-plugin.PLUGIN_NAME` to build them locally.")
 		return
@@ -43,7 +46,7 @@ func initCMDFunc(_ *cobra.Command, _ []string) {
 
 func init() {
 	initCMD.Flags().StringVarP(&configFile, configFlagName, "f", "config.yaml", "config file")
-	initCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", pluginengine.DefaultPluginDir, "plugins directory")
+	initCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", "", "plugins directory")
 
 	completion.FlagFilenameCompletion(initCMD, configFlagName)
 	completion.FlagDirnameCompletion(initCMD, pluginDirFlagName)

--- a/cmd/devstream/show.go
+++ b/cmd/devstream/show.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/devstream-io/devstream/internal/pkg/completion"
-	"github.com/devstream-io/devstream/internal/pkg/pluginengine"
 	"github.com/devstream-io/devstream/internal/pkg/show/config"
 	"github.com/devstream-io/devstream/internal/pkg/show/status"
 	"github.com/devstream-io/devstream/pkg/util/log"
@@ -67,7 +66,7 @@ func init() {
 	showStatusCMD.Flags().StringVarP(&plugin, "plugin", "p", "", "specify name with the plugin")
 	showStatusCMD.Flags().StringVarP(&instanceID, "id", "i", "", "specify id with the plugin instance")
 	showStatusCMD.Flags().BoolVarP(&statusAllFlag, "all", "a", false, "show all instances of all plugins status")
-	showStatusCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", pluginengine.DefaultPluginDir, "plugins directory")
+	showStatusCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", "", "plugins directory")
 	showStatusCMD.Flags().StringVarP(&configFile, "config-file", "f", "config.yaml", "config file")
 	completion.FlagPluginsCompletion(showStatusCMD, "plugin")
 }

--- a/cmd/devstream/verify.go
+++ b/cmd/devstream/verify.go
@@ -26,7 +26,7 @@ func verifyCMDFunc(cmd *cobra.Command, args []string) {
 
 func init() {
 	verifyCMD.Flags().StringVarP(&configFile, configFlagName, "f", "config.yaml", "config file")
-	verifyCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", pluginengine.DefaultPluginDir, "plugins directory")
+	verifyCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", "", "plugins directory")
 
 	completion.FlagFilenameCompletion(verifyCMD, configFlagName)
 	completion.FlagDirnameCompletion(verifyCMD, pluginDirFlagName)

--- a/docs/core-concepts/config.md
+++ b/docs/core-concepts/config.md
@@ -10,6 +10,7 @@ The main config contains three sections:
 
 - `varFile`: the path/to/your/variables file
 - `toolFile`: the path/to/your/tools configuration file
+- `pluginDir`: the path/to/your/plugins directory, default: `~/.devstream/plugins`, or use `-d` flag to specify a directory
 - `state`: configuration of DevStream state. For example, 
 
 ### Example Main Config File
@@ -20,6 +21,8 @@ See the `config.yaml` example below:
 varFile: variables.yaml
 
 toolFile: tools.yaml
+
+pluginDir: /usr/local/.devstream/plugins # optional
 
 state:
   backend: local

--- a/docs/core-concepts/config.md
+++ b/docs/core-concepts/config.md
@@ -22,7 +22,7 @@ varFile: variables.yaml
 
 toolFile: tools.yaml
 
-pluginDir: /usr/local/.devstream/plugins # optional
+pluginDir: /usr/local/devstream/plugins # optional
 
 state:
   backend: local

--- a/docs/core-concepts/config.zh.md
+++ b/docs/core-concepts/config.zh.md
@@ -10,6 +10,7 @@ DevStream使用YAML文件来描述你的DevOps工具链配置。
 
 - `varFile`: 指向定义变量的文件路径
 - `toolFile`: 指向定义插件的文件路径
+- `pluginDir`: 指向插件目录的路径，默认为 `~/.devstream/plugins`, 或使用 `-d` 参数指定一个目录
 - `state`: 指定DevStream状态存储位置
 
 ### 主配置文件示例
@@ -20,6 +21,8 @@ DevStream使用YAML文件来描述你的DevOps工具链配置。
 varFile: variables.yaml
 
 toolFile: tools.yaml
+
+pluginDir: /usr/local/.devstream/plugins # 可选
 
 state:
   backend: local

--- a/docs/core-concepts/config.zh.md
+++ b/docs/core-concepts/config.zh.md
@@ -22,7 +22,7 @@ varFile: variables.yaml
 
 toolFile: tools.yaml
 
-pluginDir: /usr/local/.devstream/plugins # 可选
+pluginDir: /usr/local/devstream/plugins # 可选
 
 state:
   backend: local

--- a/docs/core-concepts/core-concepts.md
+++ b/docs/core-concepts/core-concepts.md
@@ -30,6 +30,7 @@ The main config file contains:
 
 - `varFile`: the file path for the var file
 - `toolFile`: the file path for the tool file
+- `pluginDir`: the directory path for the plugin directory, default: ~/.devstream/plugins, or use `-d` flag to specify a directory
 - `state`: settings related to the state. For more information, see [here](./stateconfig.md).
 
 The variable config file is a YAML file containing keys and values, which can be used in the tool config file.

--- a/docs/core-concepts/core-concepts.zh.md
+++ b/docs/core-concepts/core-concepts.zh.md
@@ -29,6 +29,7 @@ DevStream 在配置文件中定义了 DevOps 工具链。
 
 - `varFile`: 变量配置文件的路径
 - `toolFile`: 工具文件的路径
+- `pluginDir`: 插件目录的路径，默认为 `~/.devstream/plugins`, 或使用 `-d` 参数指定一个目录
 - `state`: 与 State 关联的设置。更多信息，请看[这里](./stateconfig.md)
 
 变量配置文件是一个包含了键值对的YAML文件，可以用于工具配置文件。

--- a/docs/core-concepts/stateconfig.md
+++ b/docs/core-concepts/stateconfig.md
@@ -14,7 +14,7 @@ varFile: variables-gitops.yaml
 
 toolFile: tools-gitops.yaml
 
-pluginDir: /usr/local/.devstream/plugins # optional
+pluginDir: /usr/local/devstream/plugins # optional
 
 state:
   backend: local

--- a/docs/core-concepts/stateconfig.md
+++ b/docs/core-concepts/stateconfig.md
@@ -14,6 +14,8 @@ varFile: variables-gitops.yaml
 
 toolFile: tools-gitops.yaml
 
+pluginDir: /usr/local/.devstream/plugins # optional
+
 state:
   backend: local
   options:
@@ -30,6 +32,8 @@ TL;DR: see the config example:
 varFile: variables-gitops.yaml
 
 toolFile: tools-gitops.yaml
+
+pluginDir: /usr/local/.devstream/plugins # optional
 
 state:
   backend: s3
@@ -55,6 +59,8 @@ In short, we can use the "backend" keyword to specify where to store the state: 
 varFile: variables-gitops.yaml
 
 toolFile: tools-gitops.yaml
+
+pluginDir: /usr/local/.devstream/plugins # optional
 
 state:
   backend: s3

--- a/docs/plugins/zentao.md
+++ b/docs/plugins/zentao.md
@@ -16,6 +16,7 @@ This plugin installs [ZenTao](https://zentao.net/) in an existing Kubernetes clu
 # core config
 varFile: ''
 toolFile: ''
+pluginDir: ''
 state: # state config, backend can be local or s3
   backend: local
   options:

--- a/docs/plugins/zentao.zh.md
+++ b/docs/plugins/zentao.zh.md
@@ -15,6 +15,7 @@
 # core config
 varFile: ''
 toolFile: ''
+pluginDir: ''
 state: # state config, backend can be local or s3
   backend: local
   options:

--- a/examples/gitops.yaml
+++ b/examples/gitops.yaml
@@ -2,6 +2,7 @@
 # core config
 varFile: "" # If not empty, use the specified external variables config file
 toolFile: "" # If not empty, use the specified external tools config file
+pluginDir: "" # If empty, use the default value: ~/.devstream/plugins, or use -d flag to specify a directory
 state: # state config, backend can be local or s3
   backend: local
   options:

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -2,6 +2,7 @@
 # core config
 varFile: "" # If not empty, use the specified external variables config file
 toolFile: "" # If not empty, use the specified external tools config file
+pluginDir: "" # If empty, use the default value: ~/.devstream/plugins, or use -d flag to specify a directory
 state: # state config, backend can be local or s3
   backend: local
   options:

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v42 v42.0.0
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/mittwald/go-helm-client v0.8.4
 	github.com/onsi/ginkgo/v2 v2.1.4
@@ -28,7 +29,7 @@ require (
 	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8
-	github.com/withfig/autocomplete-tools/integrations/cobra v0.0.0-20220721102007-67b2515c5ea4
+	github.com/withfig/autocomplete-tools/integrations/cobra v0.0.0-20220812023423-ab97a51a0978
 	github.com/xanzy/go-gitlab v0.55.1
 	go.uber.org/multierr v1.6.0
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
@@ -146,7 +147,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/copystructure v1.1.1 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/moby/locker v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1270,8 +1270,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
-github.com/withfig/autocomplete-tools/integrations/cobra v0.0.0-20220721102007-67b2515c5ea4 h1:GoQuMyofxqcdyzWqVhsv5IsCL+wHoocrhUgzhtB2Nj4=
-github.com/withfig/autocomplete-tools/integrations/cobra v0.0.0-20220721102007-67b2515c5ea4/go.mod h1:nmuySobZb4kFgFy6BptpXp/BBw+xFSyvVPP6auoJB4k=
+github.com/withfig/autocomplete-tools/integrations/cobra v0.0.0-20220812023423-ab97a51a0978 h1:kIJVIF7qSnjYauW8d0kV+GGjzzTmULt8vHen1WhYcik=
+github.com/withfig/autocomplete-tools/integrations/cobra v0.0.0-20220812023423-ab97a51a0978/go.mod h1:nmuySobZb4kFgFy6BptpXp/BBw+xFSyvVPP6auoJB4k=
 github.com/xanzy/go-gitlab v0.55.1 h1:IgX/DS9buV0AUz8fuJPQkdl0fQGfBiAsAHxpun8sNhg=
 github.com/xanzy/go-gitlab v0.55.1/go.mod h1:F0QEXwmqiBUxCgJm8fE9S+1veX4XC9Z4cfaAbqwk4YM=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=

--- a/internal/pkg/configmanager/configmanager.go
+++ b/internal/pkg/configmanager/configmanager.go
@@ -20,8 +20,9 @@ var (
 
 // Config records rendered config values and is used as a general config in DevStream.
 type Config struct {
-	Tools []Tool `yaml:"tools"`
-	State *State
+	PluginDir string
+	Tools     []Tool `yaml:"tools"`
+	State     *State
 }
 
 func (c *Config) Validate() []error {
@@ -116,8 +117,9 @@ func (m *Manager) renderConfigs(coreConfigBytes, variablesConfigBytes, toolsConf
 	}
 
 	return &Config{
-		Tools: tools,
-		State: state,
+		PluginDir: coreConfig.PluginDir,
+		Tools:     tools,
+		State:     state,
 	}, nil
 }
 

--- a/internal/pkg/configmanager/coreconfig.go
+++ b/internal/pkg/configmanager/coreconfig.go
@@ -16,7 +16,9 @@ type CoreConfig struct {
 	VarFile string `yaml:"varFile"`
 	// TODO(daniel-hutao): Relative path support
 	ToolFile string `yaml:"toolFile"`
-	State    *State `yaml:"state"`
+	// abs path of the plugin dir
+	PluginDir string `yaml:"pluginDir"`
+	State     *State `yaml:"state"`
 }
 
 // State is the struct for reading the state configuration in the config file.

--- a/internal/pkg/pluginengine/cmd_apply.go
+++ b/internal/pkg/pluginengine/cmd_apply.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"os"
 
+	"github.com/devstream-io/devstream/pkg/util/file"
+
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
 	"github.com/devstream-io/devstream/internal/pkg/pluginmanager"
 	"github.com/devstream-io/devstream/internal/pkg/statemanager"
@@ -15,6 +17,8 @@ func Apply(configFile string, continueDirectly bool) error {
 	if err != nil {
 		return err
 	}
+
+	file.SetPluginDir(cfg.PluginDir)
 
 	err = pluginmanager.CheckLocalPlugins(cfg)
 	if err != nil {

--- a/internal/pkg/pluginengine/cmd_apply.go
+++ b/internal/pkg/pluginengine/cmd_apply.go
@@ -4,11 +4,10 @@ import (
 	"errors"
 	"os"
 
-	"github.com/devstream-io/devstream/pkg/util/file"
-
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
 	"github.com/devstream-io/devstream/internal/pkg/pluginmanager"
 	"github.com/devstream-io/devstream/internal/pkg/statemanager"
+	"github.com/devstream-io/devstream/pkg/util/file"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 

--- a/internal/pkg/pluginengine/cmd_delete.go
+++ b/internal/pkg/pluginengine/cmd_delete.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/devstream-io/devstream/pkg/util/file"
-
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
 	"github.com/devstream-io/devstream/internal/pkg/pluginmanager"
 	"github.com/devstream-io/devstream/internal/pkg/statemanager"
+	"github.com/devstream-io/devstream/pkg/util/file"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 

--- a/internal/pkg/pluginengine/cmd_delete.go
+++ b/internal/pkg/pluginengine/cmd_delete.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/devstream-io/devstream/pkg/util/file"
+
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
 	"github.com/devstream-io/devstream/internal/pkg/pluginmanager"
 	"github.com/devstream-io/devstream/internal/pkg/statemanager"
@@ -20,6 +22,8 @@ func Remove(configFile string, continueDirectly bool, isForceDelete bool) error 
 	if cfg == nil {
 		return fmt.Errorf("failed to load the config file")
 	}
+
+	file.SetPluginDir(cfg.PluginDir)
 
 	err = pluginmanager.CheckLocalPlugins(cfg)
 	if err != nil {

--- a/internal/pkg/pluginengine/cmd_destroy.go
+++ b/internal/pkg/pluginengine/cmd_destroy.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/devstream-io/devstream/pkg/util/file"
+
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
 	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 	"github.com/devstream-io/devstream/pkg/util/log"
@@ -18,6 +20,8 @@ func Destroy(configFile string, continueDirectly bool) error {
 	if cfg == nil {
 		return fmt.Errorf("failed to load the config file")
 	}
+
+	file.SetPluginDir(cfg.PluginDir)
 
 	smgr, err := statemanager.NewManager(*cfg.State)
 	if err != nil {

--- a/internal/pkg/pluginengine/cmd_destroy.go
+++ b/internal/pkg/pluginengine/cmd_destroy.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/devstream-io/devstream/pkg/util/file"
-
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
 	"github.com/devstream-io/devstream/internal/pkg/statemanager"
+	"github.com/devstream-io/devstream/pkg/util/file"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 

--- a/internal/pkg/pluginengine/cmd_verify.go
+++ b/internal/pkg/pluginengine/cmd_verify.go
@@ -4,6 +4,7 @@ import (
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
 	"github.com/devstream-io/devstream/internal/pkg/pluginmanager"
 	"github.com/devstream-io/devstream/internal/pkg/statemanager"
+	"github.com/devstream-io/devstream/pkg/util/file"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
@@ -18,6 +19,8 @@ func Verify(configFile string) bool {
 	if cfg == nil {
 		return false
 	}
+
+	file.SetPluginDir(cfg.PluginDir)
 
 	// 2. according to the config, all needed plugins exist
 	err = pluginmanager.CheckLocalPlugins(cfg)

--- a/internal/pkg/pluginengine/plugin.go
+++ b/internal/pkg/pluginengine/plugin.go
@@ -1,10 +1,10 @@
 package pluginengine
 
 import (
+	"github.com/spf13/viper"
+
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
 )
-
-const DefaultPluginDir = ".devstream"
 
 // DevStreamPlugin is a struct, on which Create/Read/Update/Delete interfaces are defined.
 type DevStreamPlugin interface {
@@ -18,7 +18,7 @@ type DevStreamPlugin interface {
 
 // Create loads the plugin and calls the Create method of that plugin.
 func Create(tool *configmanager.Tool) (map[string]interface{}, error) {
-	pluginDir := getPluginDir()
+	pluginDir := viper.GetString("plugin-dir")
 	p, err := loadPlugin(pluginDir, tool)
 	if err != nil {
 		return nil, err
@@ -28,7 +28,7 @@ func Create(tool *configmanager.Tool) (map[string]interface{}, error) {
 
 // Update loads the plugin and calls the Update method of that plugin.
 func Update(tool *configmanager.Tool) (map[string]interface{}, error) {
-	pluginDir := getPluginDir()
+	pluginDir := viper.GetString("plugin-dir")
 	p, err := loadPlugin(pluginDir, tool)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func Update(tool *configmanager.Tool) (map[string]interface{}, error) {
 }
 
 func Read(tool *configmanager.Tool) (map[string]interface{}, error) {
-	pluginDir := getPluginDir()
+	pluginDir := viper.GetString("plugin-dir")
 	p, err := loadPlugin(pluginDir, tool)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func Read(tool *configmanager.Tool) (map[string]interface{}, error) {
 
 // Delete loads the plugin and calls the Delete method of that plugin.
 func Delete(tool *configmanager.Tool) (bool, error) {
-	pluginDir := getPluginDir()
+	pluginDir := viper.GetString("plugin-dir")
 	p, err := loadPlugin(pluginDir, tool)
 	if err != nil {
 		return false, err

--- a/internal/pkg/pluginengine/plugin_helper.go
+++ b/internal/pkg/pluginengine/plugin_helper.go
@@ -4,18 +4,8 @@ import (
 	"fmt"
 	"plugin"
 
-	"github.com/spf13/viper"
-
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
 )
-
-func getPluginDir() string {
-	var pluginDir string
-	if pluginDir = viper.GetString("plugin-dir"); pluginDir == "" {
-		pluginDir = DefaultPluginDir
-	}
-	return pluginDir
-}
 
 func loadPlugin(pluginDir string, tool *configmanager.Tool) (DevStreamPlugin, error) {
 	mod := fmt.Sprintf("%s/%s", pluginDir, configmanager.GetPluginFileName(tool))

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -88,6 +88,9 @@ func DownloadPlugins(conf *configmanager.Config) error {
 // CheckLocalPlugins checks if the local plugins exists, and matches with md5 value.
 func CheckLocalPlugins(conf *configmanager.Config) error {
 	pluginDir := viper.GetString("plugin-dir")
+	if pluginDir == "" {
+		return fmt.Errorf(`plugins directory should not be ""`)
+	}
 
 	log.Infof("Using dir <%s> to store plugins.", pluginDir)
 

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -20,6 +20,7 @@ func DownloadPlugins(conf *configmanager.Config) error {
 	if pluginDir == "" {
 		return fmt.Errorf(`plugins directory should not be ""`)
 	}
+
 	log.Infof("Using dir <%s> to store plugins.", pluginDir)
 
 	// download all plugins that don't exist locally
@@ -87,9 +88,6 @@ func DownloadPlugins(conf *configmanager.Config) error {
 // CheckLocalPlugins checks if the local plugins exists, and matches with md5 value.
 func CheckLocalPlugins(conf *configmanager.Config) error {
 	pluginDir := viper.GetString("plugin-dir")
-	if pluginDir == "" {
-		return fmt.Errorf("plugins directory doesn't exist")
-	}
 
 	log.Infof("Using dir <%s> to store plugins.", pluginDir)
 

--- a/internal/pkg/show/status/status.go
+++ b/internal/pkg/show/status/status.go
@@ -5,13 +5,12 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/devstream-io/devstream/pkg/util/file"
-
 	"github.com/spf13/viper"
 
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
 	"github.com/devstream-io/devstream/internal/pkg/pluginengine"
 	"github.com/devstream-io/devstream/internal/pkg/statemanager"
+	"github.com/devstream-io/devstream/pkg/util/file"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 

--- a/internal/pkg/show/status/status.go
+++ b/internal/pkg/show/status/status.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/devstream-io/devstream/pkg/util/file"
+
 	"github.com/spf13/viper"
 
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
@@ -34,6 +36,8 @@ func Show(configFile string) error {
 	if cfg == nil {
 		return fmt.Errorf("failed to load the config file")
 	}
+
+	file.SetPluginDir(cfg.PluginDir)
 
 	smgr, err := statemanager.NewManager(*cfg.State)
 	if err != nil {

--- a/pkg/util/file/file.go
+++ b/pkg/util/file/file.go
@@ -2,12 +2,42 @@ package file
 
 import (
 	"os"
+	"path/filepath"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
+
+	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
 const (
 	defaultTempName    = "pkg-util-file-create_"
 	appNamePlaceHolder = "_app_name_"
 )
+
+var DefaultPluginDir string
+
+func init() {
+	homeDir, err := homedir.Dir()
+	if err != nil {
+		log.Fatalf("failed to get home dir: %s", err)
+	}
+	DefaultPluginDir = filepath.Join(homeDir, ".devstream", "plugins")
+}
+
+func GetPluginDir(conf string) string {
+	if flag := viper.GetString("plugin-dir"); flag != "" {
+		return flag
+	}
+	if conf != "" {
+		return conf
+	}
+	return DefaultPluginDir
+}
+
+func SetPluginDir(conf string) {
+	viper.Set("plugin-dir", GetPluginDir(conf))
+}
 
 // CopyFile will copy file content from src to dst
 func CopyFile(src, dest string) error {


### PR DESCRIPTION
Signed-off-by: iyear <ljyngup@gmail.com>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description
A simpler solution to the plugin absolute path problem that does not affect documentation.

The only impact is that the developer needs to specify `-d .devstream` when debugging the plugin.

## Related Issues
close #997 

## New Behavior (screenshots if needed)
The plugin version shown is for demonstration purposes only, not the actual situation.

<img width="813" alt="linux" src="https://user-images.githubusercontent.com/61452000/185288157-7d7fe902-df97-4e67-b5e0-c2c3ee21c17b.PNG">
<img width="794" alt="windows" src="https://user-images.githubusercontent.com/61452000/185288174-62b43e50-4962-45c9-b5dc-d48ed4a15a85.PNG">
<img width="897" alt="dev-plugin" src="https://user-images.githubusercontent.com/61452000/185288182-a9fbf45c-02a8-4be2-83ae-2debac325aba.PNG">



