### PR TITLE
Feat: `jenkins` plugin State Management Enhancement

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -20,3 +20,4 @@ https://pkg.go.dev/github.com/golang-standards/project-layout
 https://gitlab.com/-/profile/personal_access_tokens\?name=DevStream\+Access\+token&scopes=api
 http://core.harbor.domain/
 https://core.harbor.domain/
+http://jenkins.jenkins:8080/

--- a/internal/pkg/plugin/argocdapp/state.go
+++ b/internal/pkg/plugin/argocdapp/state.go
@@ -6,10 +6,11 @@ import (
 	"github.com/cenkalti/backoff"
 
 	"github.com/devstream-io/devstream/internal/pkg/plugininstaller"
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 	"github.com/devstream-io/devstream/pkg/util/k8s"
 )
 
-func getStaticState(options plugininstaller.RawOptions) (map[string]interface{}, error) {
+func getStaticState(options plugininstaller.RawOptions) (statemanager.ResourceState, error) {
 	opts, err := NewOptions(options)
 	if err != nil {
 		return nil, err
@@ -35,7 +36,7 @@ func getStaticState(options plugininstaller.RawOptions) (map[string]interface{},
 	return res, nil
 }
 
-func getDynamicState(options plugininstaller.RawOptions) (map[string]interface{}, error) {
+func getDynamicState(options plugininstaller.RawOptions) (statemanager.ResourceState, error) {
 	opts, err := NewOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugin/devlake/state.go
+++ b/internal/pkg/plugin/devlake/state.go
@@ -3,9 +3,10 @@ package devlake
 import (
 	"github.com/devstream-io/devstream/internal/pkg/plugininstaller"
 	"github.com/devstream-io/devstream/internal/pkg/plugininstaller/common"
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 )
 
-func getStaticState(opts plugininstaller.RawOptions) (map[string]interface{}, error) {
+func getStaticState(opts plugininstaller.RawOptions) (statemanager.ResourceState, error) {
 	res := make(map[string]interface{})
 	res["deployments"] = make(map[string]interface{})
 	res["services"] = make(map[string]interface{})
@@ -16,7 +17,7 @@ func getStaticState(opts plugininstaller.RawOptions) (map[string]interface{}, er
 	return res, nil
 }
 
-func getDynamicState(opts plugininstaller.RawOptions) (map[string]interface{}, error) {
+func getDynamicState(opts plugininstaller.RawOptions) (statemanager.ResourceState, error) {
 	labelFilter := map[string]string{
 		"app": "devlake",
 	}

--- a/internal/pkg/plugin/helmgeneric/state.go
+++ b/internal/pkg/plugin/helmgeneric/state.go
@@ -1,9 +1,12 @@
 package helmgeneric
 
-import "github.com/devstream-io/devstream/internal/pkg/plugininstaller"
+import (
+	"github.com/devstream-io/devstream/internal/pkg/plugininstaller"
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
+)
 
 // return empty
-func getEmptyState(options plugininstaller.RawOptions) (map[string]interface{}, error) {
-	retMap := make(map[string]interface{})
+func getEmptyState(options plugininstaller.RawOptions) (statemanager.ResourceState, error) {
+	retMap := make(statemanager.ResourceState)
 	return retMap, nil
 }

--- a/internal/pkg/plugin/jenkins/create.go
+++ b/internal/pkg/plugin/jenkins/create.go
@@ -19,7 +19,7 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 			helm.InstallOrUpdate,
 		},
 		TerminateOperations: helm.DefaultTerminateOperations,
-		GetStateOperation:   getHelmResourceAndCustomResource,
+		GetStateOperation:   genJenkinsState,
 	}
 
 	// Execute all Operations in Operator

--- a/internal/pkg/plugin/jenkins/jenkins.go
+++ b/internal/pkg/plugin/jenkins/jenkins.go
@@ -35,5 +35,14 @@ func genJenkinsState(options plugininstaller.RawOptions) (statemanager.ResourceS
 	}
 	resState.SetOutputs(outputs)
 
+	// values.yaml
+	opt, err := helm.NewOptions(options)
+	if err != nil {
+		return nil, err
+	}
+
+	valuesYaml := opt.GetHelmParam().Chart.ValuesYaml
+	resState["values_yaml"] = valuesYaml
+
 	return resState, nil
 }

--- a/internal/pkg/plugin/jenkins/jenkins.go
+++ b/internal/pkg/plugin/jenkins/jenkins.go
@@ -3,7 +3,7 @@ package jenkins
 import (
 	"github.com/devstream-io/devstream/internal/pkg/plugininstaller"
 	"github.com/devstream-io/devstream/internal/pkg/plugininstaller/helm"
-
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 	helmCommon "github.com/devstream-io/devstream/pkg/util/helm"
 	"github.com/devstream-io/devstream/pkg/util/types"
 )
@@ -23,16 +23,17 @@ var defaultHelmConfig = helm.Options{
 	},
 }
 
-func genJenkinsState(options plugininstaller.RawOptions) (map[string]interface{}, error) {
-	resource, err := helm.GetPluginAllState(options)
+func genJenkinsState(options plugininstaller.RawOptions) (statemanager.ResourceState, error) {
+	resState, err := helm.GetPluginAllState(options)
 	if err != nil {
 		return nil, err
 	}
 
 	// svc_name.svc_ns:svc_port
-	resource["outputs"] = map[string]interface{}{
+	outputs := map[string]interface{}{
 		"jenkins_url": "http://jenkins.jenkins:8080",
 	}
+	resState.SetOutputs(outputs)
 
-	return resource, nil
+	return resState, nil
 }

--- a/internal/pkg/plugin/jenkins/jenkins.go
+++ b/internal/pkg/plugin/jenkins/jenkins.go
@@ -23,24 +23,16 @@ var defaultHelmConfig = helm.Options{
 	},
 }
 
-// getHelmResourceAndCustomResource wraps helm resource and custom resource,
-// this is due to the limitation of `plugininstaller`,
-// now `plugininstaller.GetStateOperation` only support one resource get function,
-// if we want to use both existing resource get function(such as helm's methods) and custom function,
-// we have to wrap them into one function.
-func getHelmResourceAndCustomResource(options plugininstaller.RawOptions) (map[string]interface{}, error) {
-	// 1. get helm resource
+func genJenkinsState(options plugininstaller.RawOptions) (map[string]interface{}, error) {
 	resource, err := helm.GetPluginAllState(options)
 	if err != nil {
 		return nil, err
 	}
 
-	outputs := map[string]interface{}{}
-
-	// TODO(daniel-hutao)
-	outputs["foo"] = "bar"
-
-	resource["outputs"] = outputs
+	// svc_name.svc_ns:svc_port
+	resource["outputs"] = map[string]interface{}{
+		"jenkins_url": "http://jenkins.jenkins:8080",
+	}
 
 	return resource, nil
 }

--- a/internal/pkg/plugin/jenkins/read.go
+++ b/internal/pkg/plugin/jenkins/read.go
@@ -13,7 +13,7 @@ func Read(options map[string]interface{}) (map[string]interface{}, error) {
 			helm.SetDefaultConfig(&defaultHelmConfig),
 			helm.Validate,
 		},
-		GetStateOperation: getHelmResourceAndCustomResource,
+		GetStateOperation: genJenkinsState,
 	}
 
 	status, err := operator.Execute(plugininstaller.RawOptions(options))

--- a/internal/pkg/plugin/jenkins/update.go
+++ b/internal/pkg/plugin/jenkins/update.go
@@ -16,7 +16,7 @@ func Update(options map[string]interface{}) (map[string]interface{}, error) {
 		},
 		ExecuteOperations:   helm.DefaultUpdateOperations,
 		TerminateOperations: helm.DefaultTerminateOperations,
-		GetStateOperation:   getHelmResourceAndCustomResource,
+		GetStateOperation:   genJenkinsState,
 	}
 
 	// Execute all Operations in Operator

--- a/internal/pkg/plugin/trello/trello.go
+++ b/internal/pkg/plugin/trello/trello.go
@@ -3,6 +3,7 @@ package trello
 import (
 	"fmt"
 
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 	"github.com/devstream-io/devstream/pkg/util/log"
 	"github.com/devstream-io/devstream/pkg/util/trello"
 )
@@ -89,22 +90,22 @@ func DeleteTrelloBoard(opts *Options) error {
 	}
 	return c.CheckAndDeleteBoard(opts.Owner, opts.Repo, opts.KanbanBoardName)
 }
-func buildState(opts *Options, ti *TrelloItemId) map[string]interface{} {
-	res := make(map[string]interface{})
-	res["boardId"] = ti.boardId
-	res["todoListId"] = ti.todoListId
-	res["doingListId"] = ti.doingListId
-	res["doneListId"] = ti.doneListId
+func buildState(opts *Options, ti *TrelloItemId) statemanager.ResourceState {
+	resState := make(statemanager.ResourceState)
+	resState["boardId"] = ti.boardId
+	resState["todoListId"] = ti.todoListId
+	resState["doingListId"] = ti.doingListId
+	resState["doneListId"] = ti.doneListId
 
-	output := make(map[string]interface{})
-	output["boardId"] = ti.boardId
-	output["todoListId"] = ti.todoListId
-	output["doingListId"] = ti.doingListId
-	output["doneListId"] = ti.doneListId
+	outputs := make(map[string]interface{})
+	outputs["boardId"] = ti.boardId
+	outputs["todoListId"] = ti.todoListId
+	outputs["doingListId"] = ti.doingListId
+	outputs["doneListId"] = ti.doneListId
 
-	res["outputs"] = output
+	resState.SetOutputs(outputs)
 
-	return res
+	return resState
 }
 
 func buildReadState(opts *Options) (map[string]interface{}, error) {
@@ -117,12 +118,13 @@ func buildReadState(opts *Options) (map[string]interface{}, error) {
 		return nil, err
 	}
 
+	resState := statemanager.ResourceState(listIds)
 	output := make(map[string]interface{})
 	output["boardId"] = fmt.Sprint(listIds["boardId"])
 	output["todoListId"] = fmt.Sprint(listIds["todoListId"])
 	output["doingListId"] = fmt.Sprint(listIds["doingListId"])
 	output["doneListId"] = fmt.Sprint(listIds["doneListId"])
 
-	listIds["outputs"] = output
+	resState.SetOutputs(output)
 	return listIds, nil
 }

--- a/internal/pkg/pluginengine/pluginengine_test.go
+++ b/internal/pkg/pluginengine/pluginengine_test.go
@@ -100,16 +100,16 @@ var _ = Describe("Pluginengine", func() {
 	})
 
 	It("should handle outputs correctly", func() {
+		resState := &statemanager.ResourceState{}
+		resState.SetOutputs(map[string]interface{}{
+			"boardId":    expectedBoardId,
+			"todoListId": expectedTodoListId,
+		})
 		trelloState := statemanager.State{
 			InstanceID: "mytrelloboard",
 			Name:       "trello",
 			Options:    map[string]interface{}{},
-			Resource: map[string]interface{}{
-				"outputs": map[string]interface{}{
-					"boardId":    expectedBoardId,
-					"todoListId": expectedTodoListId,
-				},
-			},
+			Resource:   *resState,
 		}
 		err = smgr.AddState(trelloKey, trelloState)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/pkg/plugininstaller/ci/state.go
+++ b/internal/pkg/plugininstaller/ci/state.go
@@ -2,9 +2,10 @@ package ci
 
 import (
 	"github.com/devstream-io/devstream/internal/pkg/plugininstaller"
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 )
 
-func GetCIFileStatus(options plugininstaller.RawOptions) (map[string]interface{}, error) {
+func GetCIFileStatus(options plugininstaller.RawOptions) (statemanager.ResourceState, error) {
 	opts, err := NewOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugininstaller/common/state.go
+++ b/internal/pkg/plugininstaller/common/state.go
@@ -1,13 +1,13 @@
 package common
 
 import (
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 	"github.com/devstream-io/devstream/pkg/util/helm"
 	"github.com/devstream-io/devstream/pkg/util/k8s"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
-func GetPluginAllK8sState(nameSpace string, anFilter, labelFilter map[string]string) (map[string]interface{}, error) {
-
+func GetPluginAllK8sState(nameSpace string, anFilter, labelFilter map[string]string) (statemanager.ResourceState, error) {
 	// 1. init kube client
 	kubeClient, err := k8s.NewClient()
 	if err != nil {

--- a/internal/pkg/plugininstaller/docker/compose.go
+++ b/internal/pkg/plugininstaller/docker/compose.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/devstream-io/devstream/internal/pkg/plugininstaller"
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 )
 
 func ComposeUp(options plugininstaller.RawOptions) error {
@@ -22,7 +23,7 @@ func ComposeDown(options plugininstaller.RawOptions) error {
 	return nil
 }
 
-func ComposeState(options plugininstaller.RawOptions) (map[string]interface{}, error) {
+func ComposeState(options plugininstaller.RawOptions) (statemanager.ResourceState, error) {
 	state, err := op.ComposeState()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get containers state: %s", err)

--- a/internal/pkg/plugininstaller/docker/state.go
+++ b/internal/pkg/plugininstaller/docker/state.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 
 	"github.com/devstream-io/devstream/internal/pkg/plugininstaller"
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 	"github.com/devstream-io/devstream/pkg/util/docker"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
@@ -27,7 +28,7 @@ func (s *State) ToMap() (map[string]interface{}, error) {
 	return m, nil
 }
 
-func GetStaticStateFromOptions(options plugininstaller.RawOptions) (map[string]interface{}, error) {
+func GetStaticStateFromOptions(options plugininstaller.RawOptions) (statemanager.ResourceState, error) {
 	opts, err := NewOptions(options)
 	if err != nil {
 		return nil, err
@@ -43,7 +44,7 @@ func GetStaticStateFromOptions(options plugininstaller.RawOptions) (map[string]i
 	return staticState.ToMap()
 }
 
-func GetRunningState(options plugininstaller.RawOptions) (map[string]interface{}, error) {
+func GetRunningState(options plugininstaller.RawOptions) (statemanager.ResourceState, error) {
 	opts, err := NewOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugininstaller/github/state.go
+++ b/internal/pkg/plugininstaller/github/state.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 
 	"github.com/devstream-io/devstream/internal/pkg/plugininstaller"
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
-func GetStaticWorkFlowState(options plugininstaller.RawOptions) (map[string]interface{}, error) {
+func GetStaticWorkFlowState(options plugininstaller.RawOptions) (statemanager.ResourceState, error) {
 	opts, err := NewGithubActionOptions(options)
 	if err != nil {
 		return nil, err
@@ -21,7 +22,7 @@ func GetStaticWorkFlowState(options plugininstaller.RawOptions) (map[string]inte
 	return res, nil
 }
 
-func GetActionState(options plugininstaller.RawOptions) (map[string]interface{}, error) {
+func GetActionState(options plugininstaller.RawOptions) (statemanager.ResourceState, error) {
 	opts, err := NewGithubActionOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugininstaller/goclient/installer.go
+++ b/internal/pkg/plugininstaller/goclient/installer.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/devstream-io/devstream/internal/pkg/plugininstaller"
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 	"github.com/devstream-io/devstream/pkg/util/k8s"
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
@@ -373,8 +374,8 @@ func DeleteApp(options plugininstaller.RawOptions) error {
 	return nil
 }
 
-// Check plugin status by goclient
-func GetState(options plugininstaller.RawOptions) (map[string]interface{}, error) {
+// GetState checks plugin status by goclient
+func GetState(options plugininstaller.RawOptions) (statemanager.ResourceState, error) {
 	opts, err := NewOptions(options)
 	if err != nil {
 		return nil, err
@@ -391,8 +392,12 @@ func GetState(options plugininstaller.RawOptions) (map[string]interface{}, error
 	}
 
 	if !ready {
-		return map[string]interface{}{"stopped": true}, nil
+		return statemanager.ResourceState{
+			"stopped": true,
+		}, nil
 	}
 
-	return map[string]interface{}{"running": true}, nil
+	return statemanager.ResourceState{
+		"running": true,
+	}, nil
 }

--- a/internal/pkg/plugininstaller/helm/state.go
+++ b/internal/pkg/plugininstaller/helm/state.go
@@ -6,7 +6,7 @@ import (
 	"github.com/devstream-io/devstream/pkg/util/helm"
 )
 
-// GetPlugAllStateWrapper will get deploy, ds, statefulset status
+// GetPluginAllState will get the State of k8s Deployment, DaemonSet and StatefulSet resources
 func GetPluginAllState(options plugininstaller.RawOptions) (map[string]interface{}, error) {
 	opts, err := NewOptions(options)
 	if err != nil {

--- a/internal/pkg/plugininstaller/helm/state.go
+++ b/internal/pkg/plugininstaller/helm/state.go
@@ -3,11 +3,12 @@ package helm
 import (
 	"github.com/devstream-io/devstream/internal/pkg/plugininstaller"
 	"github.com/devstream-io/devstream/internal/pkg/plugininstaller/common"
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 	"github.com/devstream-io/devstream/pkg/util/helm"
 )
 
 // GetPluginAllState will get the State of k8s Deployment, DaemonSet and StatefulSet resources
-func GetPluginAllState(options plugininstaller.RawOptions) (map[string]interface{}, error) {
+func GetPluginAllState(options plugininstaller.RawOptions) (statemanager.ResourceState, error) {
 	opts, err := NewOptions(options)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/plugininstaller/plugininstaller.go
+++ b/internal/pkg/plugininstaller/plugininstaller.go
@@ -1,6 +1,9 @@
 package plugininstaller
 
-import "github.com/devstream-io/devstream/pkg/util/log"
+import (
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
 
 type RawOptions map[string]interface{}
 
@@ -10,7 +13,7 @@ type (
 	// BaseOperation reads options and executes operation
 	BaseOperation func(options RawOptions) error
 	// StateOperation reads options and executes operation, then returns the state map
-	StateOperation func(options RawOptions) (map[string]interface{}, error)
+	StateOperation func(options RawOptions) (statemanager.ResourceState, error)
 )
 
 type (

--- a/internal/pkg/statemanager/state.go
+++ b/internal/pkg/statemanager/state.go
@@ -21,6 +21,12 @@ type State struct {
 	Resource   map[string]interface{}
 }
 
+type ResourceState map[string]interface{}
+
+func (rs *ResourceState) SetOutputs(outputs map[string]interface{}) {
+	(*rs)["outputs"] = outputs
+}
+
 type StatesMap struct {
 	*concurrentmap.ConcurrentMap
 }


### PR DESCRIPTION
## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

1. `jenkins` plugin state management enhancement;
2. add `outputs` to `jenkins` plugin;
3. unify the way "outputs" are set up of all plugins;
4. docs updated.

## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->

#993

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->

- config `config-jenkins.yaml`

```yaml
---
# core config
varFile: "" # If not empty, use the specified external variables config file
toolFile: "" # If not empty, use the specified external tools config file
pluginDir: ".devstream"
state: # state config, backend can be local or s3
  backend: local
  options:
    stateFile: devstream.state

---
tools:
  # name of the tool
  - name: jenkins
    # id of the tool instance
    instanceID: default
    # format: name.instanceID; If specified, dtm will make sure the dependency is applied first before handling this tool.
    dependsOn: [ ]
    # options for the plugin
    options:
      chart:
        # custom configuration. You can refer to [Jenkins values.yaml](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml)
        values_yaml: |
          serviceAccount:
            create: true
            name: jenkins
          controller:
            adminUser: "admin"
            ingress:
              enabled: true
              hostName: jenkins.example.com
```

- apply once `./dtm apply -f config-jenkins.yaml -y`

```sh
2022-08-23 11:17:22 ℹ [INFO]  Apply started.
2022-08-23 11:17:22 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-08-23 11:17:22 ℹ [INFO]  Using local backend. State file: devstream.state.
2022-08-23 11:17:22 ℹ [INFO]  Tool (jenkins/default) found in config but doesn't exist in the state, will be created.
2022-08-23 11:17:22 ℹ [INFO]  Start executing the plan.
2022-08-23 11:17:22 ℹ [INFO]  Changes count: 1.
2022-08-23 11:17:22 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-08-23 11:17:22 ℹ [INFO]  Processing: (jenkins/default) -> Create ...
2022-08-23 11:17:23 ℹ [INFO]  Creating or updating helm chart ...
2022/08/23 11:17:26 creating 13 resource(s)
2022/08/23 11:17:27 beginning wait for 13 resources with timeout of 5m0s
2022/08/23 11:17:27 StatefulSet is not ready: jenkins/jenkins. 0 out of 1 expected pods are ready
2022/08/23 11:17:29 StatefulSet is not ready: jenkins/jenkins. 0 out of 1 expected pods are ready
...
2022/08/23 11:19:57 StatefulSet is not ready: jenkins/jenkins. 0 out of 1 expected pods are ready
2022/08/23 11:19:59 release installed successfully: jenkins/jenkins-4.1.17
2022-08-23 11:19:59 ✔ [SUCCESS]  Tool (jenkins/default) Create done.
2022-08-23 11:19:59 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-08-23 11:19:59 ✔ [SUCCESS]  All plugins applied successfully.
2022-08-23 11:19:59 ✔ [SUCCESS]  Apply finished.
```

- apply twice `./dtm apply -f config-jenkins.yaml -y`

```sh
2022-08-23 11:20:15 ℹ [INFO]  Apply started.
2022-08-23 11:20:15 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-08-23 11:20:16 ℹ [INFO]  Using local backend. State file: devstream.state.
2022-08-23 11:20:16 ℹ [INFO]  No changes done since last apply. There is nothing to do.
2022-08-23 11:20:16 ✔ [SUCCESS]  Apply finished.
```

- state `cat devstream.state`

```yaml
jenkins_default:
  name: jenkins
  instanceid: default
  dependson: []
  options:
    chart:
      values_yaml: |
        serviceAccount:
          create: true
          name: jenkins
        controller:
          adminUser: "admin"
          ingress:
            enabled: true
            hostName: jenkins.example.com
  resource:
    outputs:
      jenkins_url: http://jenkins.jenkins:8080
    values_yaml: |
      serviceAccount:
        create: true
        name: jenkins
      controller:
        adminUser: "admin"
        ingress:
          enabled: true
          hostName: jenkins.example.com
    workflows: |
      statefulsets:
        - name: jenkins
          ready: true
```

- delete `./dtm delete -f config-jenkins.yaml -y`

```sh
2022-08-23 11:21:42 ℹ [INFO]  Delete started.
2022-08-23 11:21:42 ℹ [INFO]  Using dir <.devstream> to store plugins.
2022-08-23 11:21:42 ℹ [INFO]  Using local backend. State file: devstream.state.
2022-08-23 11:21:42 ℹ [INFO]  Tool (jenkins/default) will be deleted.
2022-08-23 11:21:42 ℹ [INFO]  Start executing the plan.
2022-08-23 11:21:42 ℹ [INFO]  Changes count: 1.
2022-08-23 11:21:42 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-08-23 11:21:42 ℹ [INFO]  Processing: (jenkins/default) -> Delete ...
2022-08-23 11:21:43 ℹ [INFO]  Uninstalling jenkins helm chart.
2022/08/23 11:21:43 uninstall: Deleting jenkins
2022/08/23 11:21:44 Starting delete for "jenkins" Ingress
2022/08/23 11:21:44 Starting delete for "jenkins-agent" Service
2022/08/23 11:21:44 Starting delete for "jenkins" Service
2022/08/23 11:21:44 Starting delete for "jenkins" StatefulSet
2022/08/23 11:21:44 Starting delete for "jenkins-watch-configmaps" RoleBinding
2022/08/23 11:21:44 Starting delete for "jenkins-schedule-agents" RoleBinding
2022/08/23 11:21:44 Starting delete for "jenkins-casc-reload" Role
2022/08/23 11:21:44 Starting delete for "jenkins-schedule-agents" Role
2022/08/23 11:21:44 Starting delete for "jenkins" PersistentVolumeClaim
2022/08/23 11:21:44 Starting delete for "jenkins-jenkins-jcasc-config" ConfigMap
2022/08/23 11:21:44 Starting delete for "jenkins" ConfigMap
2022/08/23 11:21:44 Starting delete for "jenkins" Secret
2022/08/23 11:21:44 Starting delete for "jenkins" ServiceAccount
2022/08/23 11:21:44 purge requested for jenkins
2022/08/23 11:21:44 release uninstalled, response: &{0x140005edd50 }
2022-08-23 11:21:44 ℹ [INFO]  Prepare to delete 'jenkins_default' from States.
2022-08-23 11:21:44 ✔ [SUCCESS]  Tool (jenkins/default) delete done.
2022-08-23 11:21:44 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-08-23 11:21:44 ✔ [SUCCESS]  All plugins deleted successfully.
2022-08-23 11:21:44 ✔ [SUCCESS]  Delete finished.
```