### PR TITLE
fix: plugin directory render error when "~" used in the config

### DIFF
--- a/cmd/devstream/init.go
+++ b/cmd/devstream/init.go
@@ -27,7 +27,9 @@ func initCMDFunc(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	file.SetPluginDir(cfg.PluginDir)
+	if err := file.SetPluginDir(cfg.PluginDir); err != nil {
+		log.Errorf("Error: %s.", err)
+	}
 
 	if version.Dev {
 		log.Errorf("Dev version plugins can't be downloaded from the remote plugin repo; please run `make build-plugin.PLUGIN_NAME` to build them locally.")

--- a/internal/pkg/pluginengine/cmd_apply.go
+++ b/internal/pkg/pluginengine/cmd_apply.go
@@ -17,7 +17,9 @@ func Apply(configFile string, continueDirectly bool) error {
 		return err
 	}
 
-	file.SetPluginDir(cfg.PluginDir)
+	if err := file.SetPluginDir(cfg.PluginDir); err != nil {
+		log.Errorf("Error: %s.", err)
+	}
 
 	err = pluginmanager.CheckLocalPlugins(cfg)
 	if err != nil {

--- a/internal/pkg/pluginengine/cmd_delete.go
+++ b/internal/pkg/pluginengine/cmd_delete.go
@@ -22,7 +22,9 @@ func Remove(configFile string, continueDirectly bool, isForceDelete bool) error 
 		return fmt.Errorf("failed to load the config file")
 	}
 
-	file.SetPluginDir(cfg.PluginDir)
+	if err := file.SetPluginDir(cfg.PluginDir); err != nil {
+		log.Errorf("Error: %s.", err)
+	}
 
 	err = pluginmanager.CheckLocalPlugins(cfg)
 	if err != nil {

--- a/internal/pkg/pluginengine/cmd_destroy.go
+++ b/internal/pkg/pluginengine/cmd_destroy.go
@@ -20,7 +20,9 @@ func Destroy(configFile string, continueDirectly bool) error {
 		return fmt.Errorf("failed to load the config file")
 	}
 
-	file.SetPluginDir(cfg.PluginDir)
+	if err := file.SetPluginDir(cfg.PluginDir); err != nil {
+		log.Errorf("Error: %s.", err)
+	}
 
 	smgr, err := statemanager.NewManager(*cfg.State)
 	if err != nil {

--- a/internal/pkg/pluginengine/cmd_verify.go
+++ b/internal/pkg/pluginengine/cmd_verify.go
@@ -20,7 +20,9 @@ func Verify(configFile string) bool {
 		return false
 	}
 
-	file.SetPluginDir(cfg.PluginDir)
+	if err := file.SetPluginDir(cfg.PluginDir); err != nil {
+		log.Errorf("Error: %s.", err)
+	}
 
 	// 2. according to the config, all needed plugins exist
 	err = pluginmanager.CheckLocalPlugins(cfg)

--- a/internal/pkg/show/status/status.go
+++ b/internal/pkg/show/status/status.go
@@ -36,7 +36,9 @@ func Show(configFile string) error {
 		return fmt.Errorf("failed to load the config file")
 	}
 
-	file.SetPluginDir(cfg.PluginDir)
+	if err := file.SetPluginDir(cfg.PluginDir); err != nil {
+		log.Errorf("Error: %s.", err)
+	}
 
 	smgr, err := statemanager.NewManager(*cfg.State)
 	if err != nil {

--- a/pkg/util/file/file.go
+++ b/pkg/util/file/file.go
@@ -22,19 +22,20 @@ func init() {
 }
 
 func GetPluginDir(conf string) (string, error) {
-	if flag := viper.GetString("plugin-dir"); flag != "" {
-		return flag, nil
+	pluginDir := viper.GetString("plugin-dir")
+	if pluginDir == "" {
+		pluginDir = conf
 	}
 
-	if conf == "" {
+	if pluginDir == "" {
 		return DefaultPluginDir, nil
 	}
 
-	pluginDir, err := getRealPath(conf)
+	pluginRealDir, err := getRealPath(pluginDir)
 	if err != nil {
 		return "", err
 	}
-	return pluginDir, nil
+	return pluginRealDir, nil
 }
 
 // getRealPath deal with "~" in the filePath


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

fix plugin directory render error when "~" used in the config.

I've tested this pr locally.

## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->

config:

```yaml
...
pluginDir: "~/.devstream/plugins"
...
```

logs:

```sh
2022-09-01 14:28:18 ℹ [INFO]  Delete started.
2022-09-01 14:28:18 ℹ [INFO]  Using dir <~/.devstream/plugins> to store plugins.
2022-09-01 14:28:18 !! [ERROR]  Error checking required plugins. Maybe you forgot to run "dtm init" first?
2022-09-01 14:28:18 !! [ERROR]  Delete error: plugin jenkins doesn't exist.
```

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->

```sh
...
2022-09-01 15:03:17 ✔ [SUCCESS]  Tool (jenkins/default) delete done.
2022-09-01 15:03:17 λ [DEBUG]  End -> StatesMap now is:

2022-09-01 15:03:17 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-09-01 15:03:17 ✔ [SUCCESS]  All plugins deleted successfully.
2022-09-01 15:03:17 ✔ [SUCCESS]  Delete finished.
```