### PR TITLE
fix: clean before build, to avoid uploading old files

### DIFF
--- a/hack/release/auto-release-darwin-arm64.sh
+++ b/hack/release/auto-release-darwin-arm64.sh
@@ -47,6 +47,7 @@ fi
 
 # call build core and plugins
 cd ../..
+make clean
 make build -j8
 
 # install github-release for uploading


### PR DESCRIPTION
Signed-off-by: KeHaoKH <hao.ke@merico.dev>

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
make clean before make build, to avoid uploading old files
