### PR TITLE
Feat: Helm Chart Local Installation Support

### DIFF
--- a/docs/best-practices/gitlab-jenkins-harbor.zh.md
+++ b/docs/best-practices/gitlab-jenkins-harbor.zh.md
@@ -91,6 +91,7 @@ jenkins 插件的配置如下：
       name: jenkins
       url: https://charts.jenkins.io
     chart:
+      chartPath: ""
       chartName: jenkins/jenkins
       namespace: jenkins
       wait: true
@@ -204,6 +205,7 @@ tools:
       name: jenkins
       url: https://charts.jenkins.io
     chart:
+      chartPath: ""
       chartName: jenkins/jenkins
       namespace: jenkins
       wait: true

--- a/docs/best-practices/gitlab-jenkins-harbor.zh.md
+++ b/docs/best-practices/gitlab-jenkins-harbor.zh.md
@@ -91,12 +91,12 @@ jenkins 插件的配置如下：
       name: jenkins
       url: https://charts.jenkins.io
     chart:
-      chart_name: jenkins/jenkins
+      chartName: jenkins/jenkins
       namespace: jenkins
       wait: true
       timeout: 5m
       upgradeCRDs: true
-      values_yaml: |
+      valuesYaml: |
         serviceAccount:
           create: true
           name: jenkins
@@ -131,7 +131,7 @@ harbor 插件的配置如下：
   dependsOn: [ ]
   options:
     chart:
-      values_yaml: |
+      valuesYaml: |
         externalURL: http://harbor.example.com
         expose:
           type: ingress
@@ -204,12 +204,12 @@ tools:
       name: jenkins
       url: https://charts.jenkins.io
     chart:
-      chart_name: jenkins/jenkins
+      chartName: jenkins/jenkins
       namespace: jenkins
       wait: true
       timeout: 5m
       upgradeCRDs: true
-      values_yaml: |
+      valuesYaml: |
         serviceAccount:
           create: true
           name: jenkins
@@ -235,7 +235,7 @@ tools:
   dependsOn: [ ]
   options:
     chart:
-      values_yaml: |
+      valuesYaml: |
         externalURL: http://harbor.example.com
         expose:
           type: ingress

--- a/docs/core-concepts/output.md
+++ b/docs/core-concepts/output.md
@@ -69,6 +69,7 @@ tools:
       name: argo
       url: https://argoproj.github.io/argo-helm
     chart:
+      chartPath: ""
       chartName: argo/argo-cd
       releaseName: argocd
       namespace: argocd

--- a/docs/core-concepts/output.md
+++ b/docs/core-concepts/output.md
@@ -69,8 +69,8 @@ tools:
       name: argo
       url: https://argoproj.github.io/argo-helm
     chart:
-      chart_name: argo/argo-cd
-      release_name: argocd
+      chartName: argo/argo-cd
+      releaseName: argocd
       namespace: argocd
       wait: true
       timeout: 10m

--- a/docs/plugins/argocd.md
+++ b/docs/plugins/argocd.md
@@ -12,10 +12,11 @@ This plugin installs [ArgoCD](https://argoproj.github.io/cd/) in an existing Kub
 
 | key                | default value                        | description                                        |
 | ----------------   | ------------------------------------ | ------------------------------------------------   |
-| chart.chartName   | argo/argo-cd                         | chart name                                         |
+| chart.chartPath    | ""                                   | local chart path                                   |
+| chart.chartName    | argo/argo-cd                         | chart name                                         |
 | chart.timeout      | 5m                                   | this config will wait 5 minutes to deploy argocd   |
 | chart.upgradeCRDs  | true                                 | default update CRD config                          |
-| chart.releaseName | argocd                               | helm release name                                  |
+| chart.releaseName  | argocd                               | helm release name                                  |
 | chart.namespace    | argocd                               | namespace where helm to deploy                     |
 | chart.wait         | true                                 | whether to wait until installation is complete     |
 | repo.url           | https://argoproj.github.io/argo-helm | helm official repo address                         |

--- a/docs/plugins/argocd.md
+++ b/docs/plugins/argocd.md
@@ -12,13 +12,13 @@ This plugin installs [ArgoCD](https://argoproj.github.io/cd/) in an existing Kub
 
 | key                | default value                        | description                                        |
 | ----------------   | ------------------------------------ | ------------------------------------------------   |
-| chart.chart_name   | argo/argo-cd                         | chart name                                         |
+| chart.chartName   | argo/argo-cd                         | chart name                                         |
 | chart.timeout      | 5m                                   | this config will wait 5 minutes to deploy argocd   |
 | chart.upgradeCRDs  | true                                 | default update CRD config                          |
-| chart.release_name | argocd                               | helm release name                                  |
+| chart.releaseName | argocd                               | helm release name                                  |
 | chart.namespace    | argocd                               | namespace where helm to deploy                     |
 | chart.wait         | true                                 | whether to wait until installation is complete     |
 | repo.url           | https://argoproj.github.io/argo-helm | helm official repo address                         |
 | repo.name          | argo                                 | helm repo name                                     |
 
-Currently, except for `values_yaml` and default configs, all the parameters in the example above are mandatory.
+Currently, except for `valuesYaml` and default configs, all the parameters in the example above are mandatory.

--- a/docs/plugins/artifactory.md
+++ b/docs/plugins/artifactory.md
@@ -6,10 +6,10 @@ This plugin installs [artifactory](https://jfrog.com/artifactory/) in an existin
 
 ### Test/Local Dev Environment
 
-If you want to **test the plugin locally**， The following `values_yaml` configuration can be used
+If you want to **test the plugin locally**， The following `valuesYaml` configuration can be used
 
 ```yaml
-values_yaml: |
+valuesYaml: |
   artifactory:
     service:
       type: NodePort
@@ -48,12 +48,12 @@ This plugin support`Ingress`, `ClusterIP`, `NodePort` and `LoadBalancer` , You c
 
 | key                | default value           | description                                        |
 | ----               | ----                    | ----                                               |
-| chart.chart_name   | jfrog/artifactory       | chart name                                         |
+| chart.chartName   | jfrog/artifactory       | chart name                                         |
 | chart.timeout      | 10m                     | this config will wait 10 minutes to deploy         |
-| chart.release_name | artifactory             | helm release name                                  |
+| chart.releaseName | artifactory             | helm release name                                  |
 | chart.upgradeCRDs  | true                    | default update CRD config                          |
 | chart.wait         | true                    | whether to wait until installation is complete     |
 | chart.namespace    | artifactory             | namespace where helm to deploy                     |
 | repo.url           | https://charts.jfrog.io | offical helm repo address                          |
 | repo.name          | jfrog                   | helm repo name                                     |
-Currently, except for `values_yaml` and default configs, all the parameters in the example above are mandatory.
+Currently, except for `valuesYaml` and default configs, all the parameters in the example above are mandatory.

--- a/docs/plugins/artifactory.md
+++ b/docs/plugins/artifactory.md
@@ -48,9 +48,10 @@ This plugin support`Ingress`, `ClusterIP`, `NodePort` and `LoadBalancer` , You c
 
 | key                | default value           | description                                        |
 | ----               | ----                    | ----                                               |
-| chart.chartName   | jfrog/artifactory       | chart name                                         |
+| chart.chartPath    | ""                      | local chart path                                   |
+| chart.chartName    | jfrog/artifactory       | chart name                                         |
 | chart.timeout      | 10m                     | this config will wait 10 minutes to deploy         |
-| chart.releaseName | artifactory             | helm release name                                  |
+| chart.releaseName  | artifactory             | helm release name                                  |
 | chart.upgradeCRDs  | true                    | default update CRD config                          |
 | chart.wait         | true                    | whether to wait until installation is complete     |
 | chart.namespace    | artifactory             | namespace where helm to deploy                     |

--- a/docs/plugins/artifactory.zh.md
+++ b/docs/plugins/artifactory.zh.md
@@ -48,13 +48,14 @@ valuesYaml: |
 
 | key                | default value           | description                                        |
 | ----               | ----                    | ----                                               |
-| chart.chartName   | jfrog/artifactory       | helm 包名称                                        |
-| chart.timeout      | 10m                     | 等待部署成功的时间                                 |
-| chart.upgradeCRDs  | true                    | 默认更新 CRD 配置（如果存在的话）                  |
-| chart.releaseName | artifactory             | helm 发布名称                                      |
-| chart.wait         | true                    | 是否等待部署完成                                   |
-| chart.namespace    | artifactory             | helm 部署的命名空间名称                            |
-| repo.url           | https://charts.jfrog.io | helm 官方仓库地址                                  |
+| chart.chartPath    | ""                      | 本地 chart 包路径                                   |
+| chart.chartName    | jfrog/artifactory       | helm 包名称                                        |
+| chart.timeout      | 10m                     | 等待部署成功的时间                                   |
+| chart.upgradeCRDs  | true                    | 默认更新 CRD 配置（如果存在的话）                      |
+| chart.releaseName  | artifactory             | helm 发布名称                                      |
+| chart.wait         | true                    | 是否等待部署完成                                    |
+| chart.namespace    | artifactory             | helm 部署的命名空间名称                              |
+| repo.url           | https://charts.jfrog.io | helm 官方仓库地址                                   |
 | repo.name          | jfrog                   | helm 仓库名                                        |
 
 目前除了 `valuesYaml` 字段和默认配置，其它所有示例参数均为必填项。

--- a/docs/plugins/artifactory.zh.md
+++ b/docs/plugins/artifactory.zh.md
@@ -6,10 +6,10 @@
 
 ### 测试环境
 
-如果你想在**本地测试插件**， 可以使用如下 `values_yaml` 配置。
+如果你想在**本地测试插件**， 可以使用如下 `valuesYaml` 配置。
 
 ```yaml
-values_yaml: |
+valuesYaml: |
   artifactory:
     service:
       type: NodePort
@@ -48,13 +48,13 @@ values_yaml: |
 
 | key                | default value           | description                                        |
 | ----               | ----                    | ----                                               |
-| chart.chart_name   | jfrog/artifactory       | helm 包名称                                        |
+| chart.chartName   | jfrog/artifactory       | helm 包名称                                        |
 | chart.timeout      | 10m                     | 等待部署成功的时间                                 |
 | chart.upgradeCRDs  | true                    | 默认更新 CRD 配置（如果存在的话）                  |
-| chart.release_name | artifactory             | helm 发布名称                                      |
+| chart.releaseName | artifactory             | helm 发布名称                                      |
 | chart.wait         | true                    | 是否等待部署完成                                   |
 | chart.namespace    | artifactory             | helm 部署的命名空间名称                            |
 | repo.url           | https://charts.jfrog.io | helm 官方仓库地址                                  |
 | repo.name          | jfrog                   | helm 仓库名                                        |
 
-目前除了 `values_yaml` 字段和默认配置，其它所有示例参数均为必填项。
+目前除了 `valuesYaml` 字段和默认配置，其它所有示例参数均为必填项。

--- a/docs/plugins/harbor.md
+++ b/docs/plugins/harbor.md
@@ -149,13 +149,14 @@ The `harbor` plugin provides default values for many options:
 
 | key                | default value            | description                         |
 | ----               | ----                     | ----                                |
-| chart.chartName   | harbor/harbor            | helm chart name                    |
-| chart.timeout      | 10m                      | timeout for helm install               |
-| chart.upgradeCRDs  | true                     | update CRDs or not (if any)                |
-| chart.releaseName | harbor                   | helm release name                       |
-| chart.wait         | true                     | wait till deployment finishes                       |
-| chart.namespace    | harbor                   | namespace                       |
-| repo.url           | https://helm.goharbor.io | helm repo URL                        |
+| chart.chartPath    | ""                       | local chart path                    |
+| chart.chartName    | harbor/harbor            | helm chart name                     |
+| chart.timeout      | 10m                      | timeout for helm install            |
+| chart.upgradeCRDs  | true                     | update CRDs or not (if any)         |
+| chart.releaseName  | harbor                   | helm release name                   |
+| chart.wait         | true                     | wait till deployment finishes       |
+| chart.namespace    | harbor                   | namespace                           |
+| repo.url           | https://helm.goharbor.io | helm repo URL                       |
 | repo.name          | harbor                   | helm repo name                      |
 
 A maximum config is as follows:

--- a/docs/plugins/harbor.md
+++ b/docs/plugins/harbor.md
@@ -42,7 +42,7 @@ tools:
   dependsOn: [ ]
   options:
     chart:
-      values_yaml: |
+      valuesYaml: |
         externalURL: http://127.0.0.1
         expose:
           type: nodePort
@@ -149,10 +149,10 @@ The `harbor` plugin provides default values for many options:
 
 | key                | default value            | description                         |
 | ----               | ----                     | ----                                |
-| chart.chart_name   | harbor/harbor            | helm chart name                    |
+| chart.chartName   | harbor/harbor            | helm chart name                    |
 | chart.timeout      | 10m                      | timeout for helm install               |
 | chart.upgradeCRDs  | true                     | update CRDs or not (if any)                |
-| chart.release_name | harbor                   | helm release name                       |
+| chart.releaseName | harbor                   | helm release name                       |
 | chart.wait         | true                     | wait till deployment finishes                       |
 | chart.namespace    | harbor                   | namespace                       |
 | repo.url           | https://helm.goharbor.io | helm repo URL                        |

--- a/docs/plugins/harbor.zh.md
+++ b/docs/plugins/harbor.zh.md
@@ -161,10 +161,11 @@ kubectl port-forward -n harbor service/harbor --address=${ip} 80
 
 | 配置项              | 默认值                    | 描述                                 |
 | ----               | ----                     | ----                                |
-| chart.chartName   | harbor/harbor            | helm chart 包名称                    |
+| chart.chartPath    | ""                      | 本地 chart 包路径                      |
+| chart.chartName    | harbor/harbor            | helm chart 包名称                    |
 | chart.timeout      | 10m                      | helm install 的超时时间               |
-| chart.upgradeCRDs  | true                     | 是否更新 CRDs（如果有）                 |
-| chart.releaseName | harbor                   | helm 发布名称                         |
+| chart.upgradeCRDs  | true                     | 是否更新 CRDs（如果有）                |
+| chart.releaseName  | harbor                   | helm 发布名称                         |
 | chart.wait         | true                     | 是否等待部署完成                       |
 | chart.namespace    | harbor                   | 部署的命名空间                         |
 | repo.url           | https://helm.goharbor.io | helm 仓库地址                         |

--- a/docs/plugins/harbor.zh.md
+++ b/docs/plugins/harbor.zh.md
@@ -49,7 +49,7 @@ tools:
   dependsOn: [ ]
   options:
     chart:
-      values_yaml: |
+      valuesYaml: |
         externalURL: http://127.0.0.1
         expose:
           type: nodePort
@@ -161,10 +161,10 @@ kubectl port-forward -n harbor service/harbor --address=${ip} 80
 
 | 配置项              | 默认值                    | 描述                                 |
 | ----               | ----                     | ----                                |
-| chart.chart_name   | harbor/harbor            | helm chart 包名称                    |
+| chart.chartName   | harbor/harbor            | helm chart 包名称                    |
 | chart.timeout      | 10m                      | helm install 的超时时间               |
 | chart.upgradeCRDs  | true                     | 是否更新 CRDs（如果有）                 |
-| chart.release_name | harbor                   | helm 发布名称                         |
+| chart.releaseName | harbor                   | helm 发布名称                         |
 | chart.wait         | true                     | 是否等待部署完成                       |
 | chart.namespace    | harbor                   | 部署的命名空间                         |
 | repo.url           | https://helm.goharbor.io | helm 仓库地址                         |
@@ -176,7 +176,7 @@ kubectl port-forward -n harbor service/harbor --address=${ip} 80
 --8<-- "harbor.yaml"
 ```
 
-目前除了 `values_yaml` 字段和默认配置，其它所有示例参数均为必填项。
+目前除了 `valuesYaml` 字段和默认配置，其它所有示例参数均为必填项。
 
 ### 3.3、持久化存储数据
 
@@ -226,7 +226,7 @@ tools:
   dependsOn: [ ]
   options:
     chart:
-      values_yaml: |
+      valuesYaml: |
         persistence:
           persistentVolumeClaim:
             registry:
@@ -258,7 +258,7 @@ tools:
   dependsOn: [ ]
   options:
     chart:
-      values_yaml: |
+      valuesYaml: |
         externalURL: http://127.0.0.1
         expose:
           type: nodePort
@@ -273,7 +273,7 @@ tools:
   dependsOn: [ ]
   options:
     chart:
-      values_yaml: |
+      valuesYaml: |
         externalURL: http://core.harbor.domain
         expose:
           type: ingress
@@ -329,7 +329,7 @@ tools:
   dependsOn: [ ]
   options:
     chart:
-      values_yaml: |
+      valuesYaml: |
         externalURL: http://core.harbor.domain
         expose:
           type: ingress

--- a/docs/plugins/hashicorp-vault.md
+++ b/docs/plugins/hashicorp-vault.md
@@ -14,9 +14,9 @@ This plugin installs hashicorp-vault with replicas:3 by default value.
 
 | key                | default value                       | description                                        |
 | ----               | ----                                | ----                                               |
-| chart.chart_name   | hashicorp/vault                     | chart name                                         |
+| chart.chartName   | hashicorp/vault                     | chart name                                         |
 | chart.timeout      | 5m                                  | this config will wait 5 minutes to deploy          |
-| chart.release_name | vault                               | helm release name                                  |
+| chart.releaseName | vault                               | helm release name                                  |
 | chart.upgradeCRDs  | true                                | default update CRD config                          |
 | chart.wait         | true                                | whether to wait until installation is complete     |
 | chart.namespace    | vault                               | namespace where helm to deploy                     |

--- a/docs/plugins/hashicorp-vault.md
+++ b/docs/plugins/hashicorp-vault.md
@@ -14,14 +14,16 @@ This plugin installs hashicorp-vault with replicas:3 by default value.
 
 | key                | default value                       | description                                        |
 | ----               | ----                                | ----                                               |
-| chart.chartName   | hashicorp/vault                     | chart name                                         |
+| chart.chartPath    | ""                                  | local chart path                                   |
+| chart.chartName    | hashicorp/vault                     | chart name                                         |
 | chart.timeout      | 5m                                  | this config will wait 5 minutes to deploy          |
-| chart.releaseName | vault                               | helm release name                                  |
+| chart.releaseName  | vault                               | helm release name                                  |
 | chart.upgradeCRDs  | true                                | default update CRD config                          |
 | chart.wait         | true                                | whether to wait until installation is complete     |
 | chart.namespace    | vault                               | namespace where helm to deploy                     |
 | repo.url           | https://helm.releases.hashicorp.com | helm official repo address                         |
 | repo.name          | hashicorp                           | helm repo name                                     |
+
 ## Initialize all the Vault pods
 
 After installing the Vault on k8s, you can initialize all pods of the Vault on k8s. To know more about the Vault, you can refer to:

--- a/docs/plugins/jenkins-github-integ.zh.md
+++ b/docs/plugins/jenkins-github-integ.zh.md
@@ -60,9 +60,9 @@ tools:
       # Helm chart information
       chart:
         # name of the chart
-        chart_name: jenkins/jenkins
+        chartName: jenkins/jenkins
         # release name of the chart
-        release_name: dev
+        releaseName: dev
         # k8s namespace where jenkins will be installed
         namespace: jenkins
         # whether to wait for the release to be deployed or not
@@ -72,7 +72,7 @@ tools:
         # whether to perform a CRD upgrade during installation
         upgradeCRDs: true
         # custom configuration. You can refer to [Jenkins values.yaml](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml)
-        values_yaml: |
+        valuesYaml: |
           persistence:
             # for prod env: the existent storageClass, please change it
             # for test env: just ignore it, but don't remove it

--- a/docs/plugins/jenkins-github-integ.zh.md
+++ b/docs/plugins/jenkins-github-integ.zh.md
@@ -59,6 +59,8 @@ tools:
         url: https://charts.jenkins.io
       # Helm chart information
       chart:
+        # local path of the chart; if chartPath != "", repo.name and repo.url will be ignored. e.g. "foo.tgz", "./foo.tgz", "/tmp/foo.tgz"
+        chartPath: ""
         # name of the chart
         chartName: jenkins/jenkins
         # release name of the chart

--- a/docs/plugins/jenkins-pipeline-kubernetes.zh.md
+++ b/docs/plugins/jenkins-pipeline-kubernetes.zh.md
@@ -50,9 +50,9 @@ tools:
       # Helm chart information
       chart:
         # name of the chart
-        chart_name: jenkins/jenkins
+        chartName: jenkins/jenkins
         # release name of the chart
-        release_name: dev
+        releaseName: dev
         # k8s namespace where jenkins will be installed
         namespace: jenkins
         # whether to wait for the release to be deployed or not
@@ -62,7 +62,7 @@ tools:
         # whether to perform a CRD upgrade during installation
         upgradeCRDs: true
         # custom configuration. You can refer to [Jenkins values.yaml](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml)
-        values_yaml: |
+        valuesYaml: |
           persistence:
             # for prod env: the existent storageClass, please change it
             # for test env: just ignore it, but don't remove it

--- a/docs/plugins/jenkins-pipeline-kubernetes.zh.md
+++ b/docs/plugins/jenkins-pipeline-kubernetes.zh.md
@@ -49,6 +49,8 @@ tools:
         url: https://charts.jenkins.io
       # Helm chart information
       chart:
+        # local path of the chart; if chartPath != "", repo.name and repo.url will be ignored. e.g. "foo.tgz", "./foo.tgz", "/tmp/foo.tgz"
+        chartPath: ""
         # name of the chart
         chartName: jenkins/jenkins
         # release name of the chart

--- a/docs/plugins/jenkins.md
+++ b/docs/plugins/jenkins.md
@@ -16,10 +16,11 @@ Please be sure to change the `storageClass` in the options of the config to an e
 
 | key                | default value             | description                                        |
 | ----               | ----                      | ----                                               |
-| chart.chartName   | jenkins/jenkins           | chart name                                         |
+| chart.chartPath    | ""                        | local chart path                                   |
+| chart.chartName    | jenkins/jenkins           | chart name                                         |
 | chart.timeout      | 5m                        | this config will wait 5 minutes to deploy          |
 | chart.upgradeCRDs  | true                      | default update CRD config                          |
-| chart.releaseName | jenkins                   | helm release name                                  |
+| chart.releaseName  | jenkins                   | helm release name                                  |
 | chart.wait         | true                      | whether to wait until installation is complete     |
 | chart.namespace    | jenkins                   | namespace where helm to deploy                     |
 | repo.url           | https://charts.jenkins.io | helm official repo address                         |

--- a/docs/plugins/jenkins.md
+++ b/docs/plugins/jenkins.md
@@ -16,10 +16,10 @@ Please be sure to change the `storageClass` in the options of the config to an e
 
 | key                | default value             | description                                        |
 | ----               | ----                      | ----                                               |
-| chart.chart_name   | jenkins/jenkins           | chart name                                         |
+| chart.chartName   | jenkins/jenkins           | chart name                                         |
 | chart.timeout      | 5m                        | this config will wait 5 minutes to deploy          |
 | chart.upgradeCRDs  | true                      | default update CRD config                          |
-| chart.release_name | jenkins                   | helm release name                                  |
+| chart.releaseName | jenkins                   | helm release name                                  |
 | chart.wait         | true                      | whether to wait until installation is complete     |
 | chart.namespace    | jenkins                   | namespace where helm to deploy                     |
 | repo.url           | https://charts.jenkins.io | helm official repo address                         |

--- a/docs/plugins/jenkins.zh.md
+++ b/docs/plugins/jenkins.zh.md
@@ -130,10 +130,11 @@ standard (default)   k8s.io/minikube-hostpath   Delete          Immediate       
 
 | 配置项              | 默认值                     | 描述                                |
 | ----               | ----                      | ----                               |
-| chart.chartName   | jenkins/jenkins           | helm chart 包名称                   |
+| chart.chartPath    | ""                      | 本地 chart 包路径                      |
+| chart.chartName    | jenkins/jenkins           | helm chart 包名称                   |
 | chart.timeout      | 5m                        | helm install 的超时时间              |
 | chart.upgradeCRDs  | true                      | 是否更新 CRDs（如果有）               |
-| chart.releaseName | jenkins                   | helm 发布名称                        |
+| chart.releaseName  | jenkins                   | helm 发布名称                        |
 | chart.wait         | true                      | 是否等待部署完成                      |
 | chart.namespace    | jenkins                   | 部署的命名空间                        |
 | repo.url           | https://charts.jenkins.io | helm 仓库地址                        |

--- a/docs/plugins/jenkins.zh.md
+++ b/docs/plugins/jenkins.zh.md
@@ -40,7 +40,7 @@ tools:
   options:
     chart:
       # custom configuration. You can refer to [Jenkins values.yaml](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml)
-      values_yaml: |
+      valuesYaml: |
         serviceAccount:
           create: true
           name: jenkins
@@ -130,10 +130,10 @@ standard (default)   k8s.io/minikube-hostpath   Delete          Immediate       
 
 | 配置项              | 默认值                     | 描述                                |
 | ----               | ----                      | ----                               |
-| chart.chart_name   | jenkins/jenkins           | helm chart 包名称                   |
+| chart.chartName   | jenkins/jenkins           | helm chart 包名称                   |
 | chart.timeout      | 5m                        | helm install 的超时时间              |
 | chart.upgradeCRDs  | true                      | 是否更新 CRDs（如果有）               |
-| chart.release_name | jenkins                   | helm 发布名称                        |
+| chart.releaseName | jenkins                   | helm 发布名称                        |
 | chart.wait         | true                      | 是否等待部署完成                      |
 | chart.namespace    | jenkins                   | 部署的命名空间                        |
 | repo.url           | https://charts.jenkins.io | helm 仓库地址                        |
@@ -145,7 +145,7 @@ standard (default)   k8s.io/minikube-hostpath   Delete          Immediate       
 --8<-- "jenkins.yaml"
 ```
 
-目前除了 `values_yaml` 字段和默认配置，其它所有示例参数均为必填项。
+目前除了 `valuesYaml` 字段和默认配置，其它所有示例参数均为必填项。
 
 ### 2.3、持久化存储
 
@@ -164,7 +164,7 @@ tools:
   options:
     chart:
       # custom configuration. You can refer to [Jenkins values.yaml](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml)
-      values_yaml: |
+      valuesYaml: |
         serviceAccount:
           create: true
           name: jenkins
@@ -195,7 +195,7 @@ tools:
   options:
     chart:
       # custom configuration. You can refer to [Jenkins values.yaml](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml)
-      values_yaml: |
+      valuesYaml: |
         serviceAccount:
           create: true
           name: jenkins
@@ -241,7 +241,7 @@ tools:
   options:
     chart:
       # custom configuration. You can refer to [Jenkins values.yaml](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml)
-      values_yaml: |
+      valuesYaml: |
         serviceAccount:
           create: true
           name: jenkins
@@ -276,7 +276,7 @@ jenkins_default:
   dependson: []
   options:
     chart:
-      values_yaml: |
+      valuesYaml: |
         serviceAccount:
           create: true
           name: jenkins
@@ -288,7 +288,7 @@ jenkins_default:
   resource:
     outputs:
       jenkins_url: http://jenkins.jenkins:8080
-    values_yaml: |
+    valuesYaml: |
       serviceAccount:
         create: true
         name: jenkins
@@ -308,7 +308,7 @@ jenkins_default:
 ```yaml
 outputs:
   jenkins_url: http://jenkins.jenkins:8080
-values_yaml: |
+valuesYaml: |
   serviceAccount:
     create: true
     name: jenkins
@@ -323,10 +323,10 @@ workflows: |
       ready: true
 ```
 
-换言之，目前 jenkins 插件关注的状态主要是自身 StatefulSet 资源状态和 values_yaml 的配置，也就是在两种情况下会判定状态漂移，从而触发更新操作：
+换言之，目前 jenkins 插件关注的状态主要是自身 StatefulSet 资源状态和 valuesYaml 的配置，也就是在两种情况下会判定状态漂移，从而触发更新操作：
 
 1. StatefulSet 状态变更
-2. values_yaml 部分配置变更
+2. valuesYaml 部分配置变更
 
 ## 插件输出
 

--- a/docs/plugins/kube-prometheus.md
+++ b/docs/plugins/kube-prometheus.md
@@ -12,9 +12,9 @@ This plugin installs [kube-prometheus](https://github.com/prometheus-operator/ku
 
 | key                | default value                                      | description                                        |
 | ----               | ----                                               | ----                                               |
-| chart.chart_name   | prometheus-community/kube-prometheus-stack         | chart name                                         |
+| chart.chartName   | prometheus-community/kube-prometheus-stack         | chart name                                         |
 | chart.timeout      | 5m                                                 | this config will wait 5 minutes to deploy          |
-| chart.release_name | prometheus                                         | helm release name                                  |
+| chart.releaseName | prometheus                                         | helm release name                                  |
 | chart.upgradeCRDs  | true                                               | default update CRD config                          |
 | chart.wait         | true                                               | whether to wait until installation is complete     |
 | chart.namespace    | prometheus                                         | namespace where helm to deploy                     |
@@ -22,4 +22,4 @@ This plugin installs [kube-prometheus](https://github.com/prometheus-operator/ku
 | repo.name          | prometheus-community                               | helm repo name                                     |
 
 
-Currently, except for `values_yaml` and default configs, all the parameters in the example above are mandatory.
+Currently, except for `valuesYaml` and default configs, all the parameters in the example above are mandatory.

--- a/docs/plugins/kube-prometheus.md
+++ b/docs/plugins/kube-prometheus.md
@@ -12,14 +12,14 @@ This plugin installs [kube-prometheus](https://github.com/prometheus-operator/ku
 
 | key                | default value                                      | description                                        |
 | ----               | ----                                               | ----                                               |
-| chart.chartName   | prometheus-community/kube-prometheus-stack         | chart name                                         |
+| chart.chartPath    | ""                                                 | local chart path                                   |
+| chart.chartName    | prometheus-community/kube-prometheus-stack         | chart name                                         |
 | chart.timeout      | 5m                                                 | this config will wait 5 minutes to deploy          |
-| chart.releaseName | prometheus                                         | helm release name                                  |
+| chart.releaseName  | prometheus                                         | helm release name                                  |
 | chart.upgradeCRDs  | true                                               | default update CRD config                          |
 | chart.wait         | true                                               | whether to wait until installation is complete     |
 | chart.namespace    | prometheus                                         | namespace where helm to deploy                     |
 | repo.url           | https://prometheus-community.github.io/helm-charts | helm official repo address                         |
 | repo.name          | prometheus-community                               | helm repo name                                     |
-
 
 Currently, except for `valuesYaml` and default configs, all the parameters in the example above are mandatory.

--- a/docs/plugins/openldap.md
+++ b/docs/plugins/openldap.md
@@ -12,16 +12,16 @@ This plugin installs [OpenLDAP](https://www.openldap.org/) in an existing Kubern
 
 | key                | default value                             | description                                        |
 | ----               | ----                                      | ----                                               |
-| chart.chart_name   | helm-openldap/openldap-stack-ha           | community chart name                               |
+| chart.chartName   | helm-openldap/openldap-stack-ha           | community chart name                               |
 | chart.timeout      | 5m                                        | this config will wait 5 minutes to deploy          |
-| chart.release_name | openldap                                  | helm release name                                  |
+| chart.releaseName | openldap                                  | helm release name                                  |
 | chart.upgradeCRDs  | true                                      | default update CRD config                          |
 | chart.wait         | true                                      | whether to wait until installation is complete     |
 | chart.namespace    | openldap                                  | namespace where helm to deploy                     |
 | repo.url           | https://jp-gouin.github.io/helm-openldap/ | helm repo address                                  |
 | repo.name          | helm-openldap                             | helm repo name                                     |
 
-## Description of Key Fields in `values_yaml`
+## Description of Key Fields in `valuesYaml`
 
 - `replicaCount`: The default value is 3, for the convenience of local testing, the above example is set to 1
 - `service.type`: The default value is `ClusterIP`, if you have services outside the Kubernetes cluster that require ldap integration, the value preferably be set to `NodePort`, so that services outside the Kubernetes cluster can access the ldap service via `ldap://ip:389` instead of `ldap://openldap.openldap-openldap-stack-ha:389`
@@ -162,4 +162,4 @@ result: 0 Success
 # numEntries: 1
 ```
 
-If your command output is as above, your ldap service is fine. The above `values_yaml` is only to facilitate your local testing, if you want production available, you also have to configure `replicaCount`, data persistence, etc., refer to [OpenLDAP values.yaml](https://github.com/jp-gouin/helm-openldap/blob/master/values.yaml)
+If your command output is as above, your ldap service is fine. The above `valuesYaml` is only to facilitate your local testing, if you want production available, you also have to configure `replicaCount`, data persistence, etc., refer to [OpenLDAP values.yaml](https://github.com/jp-gouin/helm-openldap/blob/master/values.yaml)

--- a/docs/plugins/openldap.md
+++ b/docs/plugins/openldap.md
@@ -12,9 +12,10 @@ This plugin installs [OpenLDAP](https://www.openldap.org/) in an existing Kubern
 
 | key                | default value                             | description                                        |
 | ----               | ----                                      | ----                                               |
-| chart.chartName   | helm-openldap/openldap-stack-ha           | community chart name                               |
+| chart.chartPath    | ""                                        | local chart path                                   |
+| chart.chartName    | helm-openldap/openldap-stack-ha           | community chart name                               |
 | chart.timeout      | 5m                                        | this config will wait 5 minutes to deploy          |
-| chart.releaseName | openldap                                  | helm release name                                  |
+| chart.releaseName  | openldap                                  | helm release name                                  |
 | chart.upgradeCRDs  | true                                      | default update CRD config                          |
 | chart.wait         | true                                      | whether to wait until installation is complete     |
 | chart.namespace    | openldap                                  | namespace where helm to deploy                     |

--- a/docs/plugins/tekton.md
+++ b/docs/plugins/tekton.md
@@ -11,6 +11,7 @@ This plugin installs [tekton](https://tekton.dev/) in an existing Kubernetes clu
 
 | key                | default value                                   | description                                        |
 | ----               | ----                                            | ----                                               |
+| chart.chartPath    | ""                                              | local chart path                                   |
 | chart.chartName    | tekton/tekton-pipeline                          | chart name                                         |
 | chart.timeout      | 5m                                              | this config will wait 5 minutes to deploy          |
 | chart.upgradeCRDs  | true                                            | default update CRD config                          |

--- a/docs/plugins/tekton.md
+++ b/docs/plugins/tekton.md
@@ -11,14 +11,14 @@ This plugin installs [tekton](https://tekton.dev/) in an existing Kubernetes clu
 
 | key                | default value                                   | description                                        |
 | ----               | ----                                            | ----                                               |
-| chart.chart_name   | tekton/tekton-pipeline                          | chart name                                         |
+| chart.chartName    | tekton/tekton-pipeline                          | chart name                                         |
 | chart.timeout      | 5m                                              | this config will wait 5 minutes to deploy          |
 | chart.upgradeCRDs  | true                                            | default update CRD config                          |
-| chart.release_name | tekton                                          | helm release name                                  |
+| chart.releaseName  | tekton                                          | helm release name                                  |
 | chart.wait         | true                                            | whether to wait until installation is complete     |
 | chart.namespace    | tekton                                          | namespace where helm to deploy                     |
 | repo.url           | https://steinliber.github.io/tekton-helm-chart/ | helm community repo address                        |
 | repo.name          | tekton                                          | helm repo name                                     |
 
 
-Currently, except for `values_yaml` and default configs, all the parameters in the example above are mandatory.
+Currently, except for `valuesYaml` and default configs, all the parameters in the example above are mandatory.

--- a/docs/plugins/tekton.zh.md
+++ b/docs/plugins/tekton.zh.md
@@ -8,15 +8,16 @@
 
 ### Default Configs
 
-| key                | default value                                   | description                                        |
-| ----               | ----                                            | ----                                               |
-| chart.chartName    | tekton/tekton-pipeline                          | helm 包名称                                        |
-| chart.timeout      | 5m                                              | 等待部署成功的时间                                 |
-| chart.upgradeCRDs  | true                                            | 默认更新 CRD 配置（如果存在的话）                  |
-| chart.releaseName  | tekton                                          | helm 发布名称                                      |
+| key                | default value                                   | description                                      |
+| ----               | ----                                            | ----                                             |
+| chart.chartPath    | ""                                              | 本地 chart 包路径                                  |
+| chart.chartName    | tekton/tekton-pipeline                          | helm 包名称                                       |
+| chart.timeout      | 5m                                              | 等待部署成功的时间                                  |
+| chart.upgradeCRDs  | true                                            | 默认更新 CRD 配置（如果存在的话）                     |
+| chart.releaseName  | tekton                                          | helm 发布名称                                     |
 | chart.wait         | true                                            | 是否等待部署完成                                   |
-| chart.namespace    | tekton                                          | helm 部署的命名空间名称                            |
+| chart.namespace    | tekton                                          | helm 部署的命名空间名称                             |
 | repo.url           | https://steinliber.github.io/tekton-helm-chart/ | helm 官方仓库地址                                  |
-| repo.name          | tekton                                          | helm 仓库名                                        |
+| repo.name          | tekton                                          | helm 仓库名                                       |
 
 目前除了 `valuesYaml` 和默认配置，以上其它配置项均为必填项。

--- a/docs/plugins/tekton.zh.md
+++ b/docs/plugins/tekton.zh.md
@@ -10,13 +10,13 @@
 
 | key                | default value                                   | description                                        |
 | ----               | ----                                            | ----                                               |
-| chart.chart_name   | tekton/tekton-pipeline                          | helm 包名称                                        |
+| chart.chartName    | tekton/tekton-pipeline                          | helm 包名称                                        |
 | chart.timeout      | 5m                                              | 等待部署成功的时间                                 |
 | chart.upgradeCRDs  | true                                            | 默认更新 CRD 配置（如果存在的话）                  |
-| chart.release_name | tekton                                          | helm 发布名称                                      |
+| chart.releaseName  | tekton                                          | helm 发布名称                                      |
 | chart.wait         | true                                            | 是否等待部署完成                                   |
 | chart.namespace    | tekton                                          | helm 部署的命名空间名称                            |
 | repo.url           | https://steinliber.github.io/tekton-helm-chart/ | helm 官方仓库地址                                  |
 | repo.name          | tekton                                          | helm 仓库名                                        |
 
-目前除了 `values_yaml` 和默认配置，以上其它配置项均为必填项。
+目前除了 `valuesYaml` 和默认配置，以上其它配置项均为必填项。

--- a/examples/gitops.yaml
+++ b/examples/gitops.yaml
@@ -82,6 +82,7 @@ tools:
         name: argo
         url: https://argoproj.github.io/argo-helm
       chart:
+        chartPath: ""
         chartName: argo/argo-cd
         releaseName: argocd
         namespace: [[ argocdNameSpace ]]

--- a/examples/gitops.yaml
+++ b/examples/gitops.yaml
@@ -82,8 +82,8 @@ tools:
         name: argo
         url: https://argoproj.github.io/argo-helm
       chart:
-        chart_name: argo/argo-cd
-        release_name: argocd
+        chartName: argo/argo-cd
+        releaseName: argocd
         namespace: [[ argocdNameSpace ]]
         wait: true
         timeout: [[ argocdDeployTimeout ]]

--- a/internal/pkg/plugin/argocd/argocd.go
+++ b/internal/pkg/plugin/argocd/argocd.go
@@ -8,6 +8,7 @@ import (
 
 var defaultHelmConfig = helm.Options{
 	Chart: helmCommon.Chart{
+		ChartPath:   "",
 		ChartName:   "argo/argo-cd",
 		Timeout:     "5m",
 		Wait:        types.Bool(true),

--- a/internal/pkg/plugin/artifactory/artifactory.go
+++ b/internal/pkg/plugin/artifactory/artifactory.go
@@ -8,6 +8,7 @@ import (
 
 var defaultHelmConfig = helm.Options{
 	Chart: helmCommon.Chart{
+		ChartPath:   "",
 		ChartName:   "jfrog/artifactory",
 		Timeout:     "10m",
 		UpgradeCRDs: types.Bool(true),

--- a/internal/pkg/plugin/harbor/harbor.go
+++ b/internal/pkg/plugin/harbor/harbor.go
@@ -8,6 +8,7 @@ import (
 
 var defaultHelmConfig = helm.Options{
 	Chart: helmCommon.Chart{
+		ChartPath:   "",
 		ChartName:   "harbor/harbor",
 		Timeout:     "10m",
 		UpgradeCRDs: types.Bool(true),

--- a/internal/pkg/plugin/hashicorpvault/hashicorpvault.go
+++ b/internal/pkg/plugin/hashicorpvault/hashicorpvault.go
@@ -8,6 +8,7 @@ import (
 
 var defaultHelmConfig = helm.Options{
 	Chart: helmCommon.Chart{
+		ChartPath:   "",
 		ChartName:   "hashicorp/vault",
 		Timeout:     "5m",
 		UpgradeCRDs: types.Bool(true),

--- a/internal/pkg/plugin/jenkins/jenkins.go
+++ b/internal/pkg/plugin/jenkins/jenkins.go
@@ -13,6 +13,7 @@ import (
 
 var defaultHelmConfig = helm.Options{
 	Chart: helmCommon.Chart{
+		ChartPath:   "",
 		ChartName:   "jenkins/jenkins",
 		Timeout:     "5m",
 		UpgradeCRDs: types.Bool(true),

--- a/internal/pkg/plugin/jenkins/jenkins.go
+++ b/internal/pkg/plugin/jenkins/jenkins.go
@@ -38,7 +38,7 @@ func genJenkinsState(options plugininstaller.RawOptions) (statemanager.ResourceS
 		return nil, err
 	}
 	valuesYaml := opt.GetHelmParam().Chart.ValuesYaml
-	resState["values_yaml"] = valuesYaml
+	resState["valuesYaml"] = valuesYaml
 
 	svcName, err := genJenkinsSvcName(options)
 	if err != nil {

--- a/internal/pkg/plugin/kubeprometheus/kubeprometheus.go
+++ b/internal/pkg/plugin/kubeprometheus/kubeprometheus.go
@@ -8,6 +8,7 @@ import (
 
 var defaultHelmConfig = helm.Options{
 	Chart: helmCommon.Chart{
+		ChartPath:   "",
 		ChartName:   "prometheus-community/kube-prometheus-stack",
 		Timeout:     "5m",
 		UpgradeCRDs: types.Bool(true),

--- a/internal/pkg/plugin/openldap/openldap.go
+++ b/internal/pkg/plugin/openldap/openldap.go
@@ -8,6 +8,7 @@ import (
 
 var defaultHelmConfig = helm.Options{
 	Chart: helmCommon.Chart{
+		ChartPath:   "",
 		ChartName:   "helm-openldap/openldap-stack-ha",
 		Timeout:     "5m",
 		UpgradeCRDs: types.Bool(true),

--- a/internal/pkg/plugin/tekton/tekton.go
+++ b/internal/pkg/plugin/tekton/tekton.go
@@ -8,6 +8,7 @@ import (
 
 var defaultHelmConfig = helm.Options{
 	Chart: helmCommon.Chart{
+		ChartPath:   "",
 		ChartName:   "tekton/tekton-pipeline",
 		Timeout:     "5m",
 		UpgradeCRDs: types.Bool(true),

--- a/internal/pkg/plugininstaller/helm/option_test.go
+++ b/internal/pkg/plugininstaller/helm/option_test.go
@@ -38,14 +38,14 @@ var _ = Describe("Options struct", func() {
 				"url":  "",
 			},
 			"chart": map[string]interface{}{
-				"version":      "",
-				"release_name": "",
-				"wait":         emptyBool,
-				"chart_name":   "test_chart",
-				"namespace":    "test_nameSpace",
-				"timeout":      "",
-				"upgradeCRDs":  emptyBool,
-				"values_yaml":  "",
+				"version":     "",
+				"releaseName": "",
+				"wait":        emptyBool,
+				"chartName":   "test_chart",
+				"namespace":   "test_nameSpace",
+				"timeout":     "",
+				"upgradeCRDs": emptyBool,
+				"valuesYaml":  "",
 			},
 		}
 	})
@@ -95,7 +95,7 @@ var _ = Describe("NewOptions func", func() {
 				"name": testRepoName,
 			},
 			"chart": map[string]interface{}{
-				"chart_name": testChartName,
+				"chartName": testChartName,
 			},
 		}
 	})

--- a/internal/pkg/plugininstaller/helm/option_test.go
+++ b/internal/pkg/plugininstaller/helm/option_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Options struct", func() {
 				"version":     "",
 				"releaseName": "",
 				"wait":        emptyBool,
+				"chartPath":   "",
 				"chartName":   "test_chart",
 				"namespace":   "test_nameSpace",
 				"timeout":     "",

--- a/internal/pkg/plugininstaller/helm/validate_test.go
+++ b/internal/pkg/plugininstaller/helm/validate_test.go
@@ -78,6 +78,7 @@ var _ = Describe("SetDefaultConfig func", func() {
 			},
 		}
 		expectChart = map[string]interface{}{
+			"chartPath":   "",
 			"chartName":   testChartName,
 			"wait":        testBool,
 			"namespace":   "",

--- a/internal/pkg/plugininstaller/helm/validate_test.go
+++ b/internal/pkg/plugininstaller/helm/validate_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Validate func", func() {
 		BeforeEach(func() {
 			testOption = map[string]interface{}{
 				"chart": map[string]string{
-					"chart_name": "test",
+					"chartName": "test",
 				},
 				"repo": map[string]string{
 					"url":  "http://test.com",
@@ -78,14 +78,14 @@ var _ = Describe("SetDefaultConfig func", func() {
 			},
 		}
 		expectChart = map[string]interface{}{
-			"chart_name":   testChartName,
-			"wait":         testBool,
-			"namespace":    "",
-			"version":      "",
-			"release_name": "",
-			"values_yaml":  "",
-			"timeout":      "",
-			"upgradeCRDs":  testBool,
+			"chartName":   testChartName,
+			"wait":        testBool,
+			"namespace":   "",
+			"version":     "",
+			"releaseName": "",
+			"valuesYaml":  "",
+			"timeout":     "",
+			"upgradeCRDs": testBool,
 		}
 		expectRepo = map[string]interface{}{
 			"url":  testRepoURL,

--- a/internal/pkg/show/config/plugins/argocd.yaml
+++ b/internal/pkg/show/config/plugins/argocd.yaml
@@ -16,9 +16,9 @@ tools:
       # Helm chart information
       chart:
         # name of the chart
-        chart_name: argo/argo-cd
+        chartName: argo/argo-cd
         # release name of the chart
-        release_name: argocd
+        releaseName: argocd
         # k8s namespace where ArgoCD will be installed
         namespace: argocd
         # whether to wait for the release to be deployed or not
@@ -28,7 +28,7 @@ tools:
         # whether to perform a CRD upgrade during installation
         upgradeCRDs: true
         # custom configuration (Optional). You can refer to [ArgoCD values.yaml](https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml)
-        values_yaml: |
+        valuesYaml: |
           controller:
             service:
               port: 8080

--- a/internal/pkg/show/config/plugins/argocd.yaml
+++ b/internal/pkg/show/config/plugins/argocd.yaml
@@ -15,6 +15,8 @@ tools:
         url: https://argoproj.github.io/argo-helm
       # Helm chart information
       chart:
+        # local path of the chart; if chartPath != "", repo.name and repo.url will be ignored. e.g. "foo.tgz", "./foo.tgz", "/tmp/foo.tgz"
+        chartPath: ""
         # name of the chart
         chartName: argo/argo-cd
         # release name of the chart

--- a/internal/pkg/show/config/plugins/artifactory.yaml
+++ b/internal/pkg/show/config/plugins/artifactory.yaml
@@ -14,18 +14,18 @@ tools:
     # Helm chart information
     chart:
       # name of the chart
-      chart_name: jfrog/artifactory
+      chartName: jfrog/artifactory
       # k8s namespace where Harbor will be installed
       namespace: artifactory
       # release name of the chart
-      release_name: artifactory
+      releaseName: artifactory
       # whether to wait for the release to be deployed or not
       wait: true
       # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 10m
       timeout: 10m
       # whether to perform a CRD upgrade during installation
       upgradeCRDs: true
-      # values_yaml: |
+      # valuesYaml: |
         # artifactory:
           # service:
             # type: NodePort

--- a/internal/pkg/show/config/plugins/artifactory.yaml
+++ b/internal/pkg/show/config/plugins/artifactory.yaml
@@ -13,6 +13,8 @@ tools:
       url: https://charts.jfrog.io
     # Helm chart information
     chart:
+      # local path of the chart; if chartPath != "", repo.name and repo.url will be ignored. e.g. "foo.tgz", "./foo.tgz", "/tmp/foo.tgz"
+      chartPath: ""
       # name of the chart
       chartName: jfrog/artifactory
       # k8s namespace where Harbor will be installed

--- a/internal/pkg/show/config/plugins/harbor.yaml
+++ b/internal/pkg/show/config/plugins/harbor.yaml
@@ -14,18 +14,18 @@ tools:
     # Helm chart information
     chart:
       # name of the chart
-      chart_name: harbor/harbor
+      chartName: harbor/harbor
       # k8s namespace where Harbor will be installed
       namespace: harbor
       # release name of the chart
-      release_name: harbor
+      releaseName: harbor
       # whether to wait for the release to be deployed or not
       wait: true
       # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 10m
       timeout: 10m
       # whether to perform a CRD upgrade during installation
       upgradeCRDs: true
-      values_yaml: |
+      valuesYaml: |
         externalURL: http://127.0.0.1
         expose:
           type: nodePort

--- a/internal/pkg/show/config/plugins/harbor.yaml
+++ b/internal/pkg/show/config/plugins/harbor.yaml
@@ -13,6 +13,8 @@ tools:
       url: https://helm.goharbor.io
     # Helm chart information
     chart:
+      # local path of the chart; if chartPath != "", repo.name and repo.url will be ignored. e.g. "foo.tgz", "./foo.tgz", "/tmp/foo.tgz"
+      chartPath: ""
       # name of the chart
       chartName: harbor/harbor
       # k8s namespace where Harbor will be installed

--- a/internal/pkg/show/config/plugins/hashicorp-vault.yaml
+++ b/internal/pkg/show/config/plugins/hashicorp-vault.yaml
@@ -10,6 +10,8 @@ tools:
         url: https://helm.releases.hashicorp.com
       # Helm chart information
       chart:
+        # local path of the chart; if chartPath != "", repo.name and repo.url will be ignored. e.g. "foo.tgz", "./foo.tgz", "/tmp/foo.tgz"
+        chartPath: ""
         # name of the chart
         chartName: hashicorp/vault
         # release name of the chart

--- a/internal/pkg/show/config/plugins/hashicorp-vault.yaml
+++ b/internal/pkg/show/config/plugins/hashicorp-vault.yaml
@@ -11,16 +11,16 @@ tools:
       # Helm chart information
       chart:
         # name of the chart
-        chart_name: hashicorp/vault
+        chartName: hashicorp/vault
         # release name of the chart
-        release_name: vault
+        releaseName: vault
         # k8s namespace where Vault will be installed
         namespace: vault
         # whether to wait for the release to be deployed or not
         wait: true
         # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 5m
         timeout: 5m
-        values_yaml: |
+        valuesYaml: |
           global:
             enabled: true
           server:

--- a/internal/pkg/show/config/plugins/helm-generic.yaml
+++ b/internal/pkg/show/config/plugins/helm-generic.yaml
@@ -14,6 +14,8 @@ tools:
         url: YOUR_CHART_REPO
       # Helm chart information
       chart:
+        # local path of the chart; if chartPath != "", repo.name and repo.url will be ignored. e.g. "foo.tgz", "./foo.tgz", "/tmp/foo.tgz"
+        chartPath: ""
         # name of the chart, e.g. argo/argo-cd
         chartName: CHART_NAME
         # release name of the chart, e.g. argocd

--- a/internal/pkg/show/config/plugins/helm-generic.yaml
+++ b/internal/pkg/show/config/plugins/helm-generic.yaml
@@ -15,9 +15,9 @@ tools:
       # Helm chart information
       chart:
         # name of the chart, e.g. argo/argo-cd
-        chart_name: CHART_NAME
+        chartName: CHART_NAME
         # release name of the chart, e.g. argocd
-        release_name: RELEASE_NAME
+        releaseName: RELEASE_NAME
         # k8s namespace, e.g. argocd
         namespace: YOUR_CHART_NAMESPACE
         # whether to wait for the release to be deployed or not
@@ -27,5 +27,5 @@ tools:
         # whether to perform a CRD upgrade during installation
         upgradeCRDs: true
         # custom configuration (Optional). e.g. You can refer to [ArgoCD values.yaml](https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml)
-        values_yaml: |
+        valuesYaml: |
           FOO: BAR

--- a/internal/pkg/show/config/plugins/jenkins.yaml
+++ b/internal/pkg/show/config/plugins/jenkins.yaml
@@ -15,6 +15,8 @@ tools:
       url: https://charts.jenkins.io
     # Helm chart information
     chart:
+      # local path of the chart; if chartPath != "", repo.name and repo.url will be ignored. e.g. "foo.tgz", "./foo.tgz", "/tmp/foo.tgz"
+      chartPath: ""
       # name of the chart
       chartName: jenkins/jenkins
       # k8s namespace where jenkins will be installed

--- a/internal/pkg/show/config/plugins/jenkins.yaml
+++ b/internal/pkg/show/config/plugins/jenkins.yaml
@@ -16,7 +16,7 @@ tools:
     # Helm chart information
     chart:
       # name of the chart
-      chart_name: jenkins/jenkins
+      chartName: jenkins/jenkins
       # k8s namespace where jenkins will be installed
       namespace: jenkins
       # whether to wait for the release to be deployed or not
@@ -26,7 +26,7 @@ tools:
       # whether to perform a CRD upgrade during installation
       upgradeCRDs: true
       # custom configuration. You can refer to [Jenkins values.yaml](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml)
-      values_yaml: |
+      valuesYaml: |
         persistence:
           storageClass: ""
         serviceAccount:

--- a/internal/pkg/show/config/plugins/kube-prometheus.yaml
+++ b/internal/pkg/show/config/plugins/kube-prometheus.yaml
@@ -15,6 +15,8 @@ tools:
         url: https://prometheus-community.github.io/helm-charts
       # Helm chart information
       chart:
+        # local path of the chart; if chartPath != "", repo.name and repo.url will be ignored. e.g. "foo.tgz", "./foo.tgz", "/tmp/foo.tgz"
+        chartPath: ""
         # name of the chart
         chartName: prometheus-community/kube-prometheus-stack
         # release name of the chart

--- a/internal/pkg/show/config/plugins/kube-prometheus.yaml
+++ b/internal/pkg/show/config/plugins/kube-prometheus.yaml
@@ -16,9 +16,9 @@ tools:
       # Helm chart information
       chart:
         # name of the chart
-        chart_name: prometheus-community/kube-prometheus-stack
+        chartName: prometheus-community/kube-prometheus-stack
         # release name of the chart
-        release_name: prometheus
+        releaseName: prometheus
         # k8s namespace where kube-prometheus will be installed
         namespace: prometheus
         # whether to wait for the release to be deployed or not
@@ -28,5 +28,5 @@ tools:
         # whether to perform a CRD upgrade during installation
         upgradeCRDs: true
         # custom configuration (Optional). You can refer to [kube-prometheus-stack values.yaml](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml)
-        values_yaml: |
+        valuesYaml: |
           namespaceOverride: "monitoring"

--- a/internal/pkg/show/config/plugins/openldap.yaml
+++ b/internal/pkg/show/config/plugins/openldap.yaml
@@ -15,9 +15,9 @@ tools:
       # Helm chart information
       chart:
         # name of the chart
-        chart_name: helm-openldap/openldap-stack-ha
+        chartName: helm-openldap/openldap-stack-ha
         # release name of the chart
-        release_name: openldap
+        releaseName: openldap
         # k8s namespace where OpenLDAP will be installed
         namespace: openldap
         # whether to wait for the release to be deployed or not
@@ -25,7 +25,7 @@ tools:
         # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 5m
         timeout: 5m
         # custom configuration (Optional). You can refer to https://github.com/jp-gouin/helm-openldap/blob/master/values.yaml
-        values_yaml: |
+        valuesYaml: |
           replicaCount: 1
           service:
             type: NodePort

--- a/internal/pkg/show/config/plugins/openldap.yaml
+++ b/internal/pkg/show/config/plugins/openldap.yaml
@@ -14,6 +14,8 @@ tools:
         url: https://jp-gouin.github.io/helm-openldap/
       # Helm chart information
       chart:
+        # local path of the chart; if chartPath != "", repo.name and repo.url will be ignored. e.g. "foo.tgz", "./foo.tgz", "/tmp/foo.tgz"
+        chartPath: ""
         # name of the chart
         chartName: helm-openldap/openldap-stack-ha
         # release name of the chart

--- a/internal/pkg/show/config/plugins/tekton.yaml
+++ b/internal/pkg/show/config/plugins/tekton.yaml
@@ -15,17 +15,17 @@ tools:
       # Helm chart information
       chart:
         # name of the chart
-        chart_name: tekton/tekton-pipeline
+        chartName: tekton/tekton-pipeline
         # k8s namespace where Tekton will be installed
         namespace: tekton
         # release name of the chart
-        release_name: tekton
+        releaseName: tekton
         # whether to wait for the release to be deployed or not
         wait: true
         # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 5m0s
         timeout: 5m
         # whether to perform a CRD upgrade during installation
         upgradeCRDs: true
-        values_yaml: |
+        valuesYaml: |
           serviceaccount:
             enabled: true

--- a/internal/pkg/show/config/plugins/tekton.yaml
+++ b/internal/pkg/show/config/plugins/tekton.yaml
@@ -14,6 +14,8 @@ tools:
         url: https://steinliber.github.io/tekton-helm-chart/
       # Helm chart information
       chart:
+        # local path of the chart; if chartPath != "", repo.name and repo.url will be ignored. e.g. "foo.tgz", "./foo.tgz", "/tmp/foo.tgz"
+        chartPath: ""
         # name of the chart
         chartName: tekton/tekton-pipeline
         # k8s namespace where Tekton will be installed

--- a/internal/pkg/show/config/templates/gitops.yaml
+++ b/internal/pkg/show/config/templates/gitops.yaml
@@ -82,6 +82,7 @@ tools:
         name: argo
         url: https://argoproj.github.io/argo-helm
       chart:
+        chartPath: ""
         chartName: argo/argo-cd
         releaseName: argocd
         namespace: [[ argocdNameSpace ]]

--- a/internal/pkg/show/config/templates/gitops.yaml
+++ b/internal/pkg/show/config/templates/gitops.yaml
@@ -82,8 +82,8 @@ tools:
         name: argo
         url: https://argoproj.github.io/argo-helm
       chart:
-        chart_name: argo/argo-cd
-        release_name: argocd
+        chartName: argo/argo-cd
+        releaseName: argocd
         namespace: [[ argocdNameSpace ]]
         wait: true
         timeout: [[ argocdDeployTimeout ]]

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -38,6 +38,7 @@ func NewHelm(param *HelmParam, option ...Option) (*Helm, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	entry := &repo.Entry{
 		Name:                  param.Repo.Name,
 		URL:                   param.Repo.URL,
@@ -83,6 +84,13 @@ func NewHelm(param *HelmParam, option ...Option) (*Helm, error) {
 		CleanupOnFail:    false,
 		DryRun:           false,
 	}
+	if param.Chart.ChartPath != "" {
+		chartSpec.ChartName = param.Chart.ChartPath
+		if err = cacheChartPackage(param.Chart.ChartPath); err != nil {
+			return nil, err
+		}
+	}
+
 	h := &Helm{
 		Entry:     entry,
 		ChartSpec: chartSpec,
@@ -93,9 +101,12 @@ func NewHelm(param *HelmParam, option ...Option) (*Helm, error) {
 		op(h)
 	}
 
-	if err = h.AddOrUpdateChartRepo(*entry); err != nil {
-		return nil, err
+	if param.Chart.ChartPath == "" {
+		if err = h.AddOrUpdateChartRepo(*entry); err != nil {
+			return nil, err
+		}
 	}
+
 	return h, nil
 }
 

--- a/pkg/util/helm/helm.go
+++ b/pkg/util/helm/helm.go
@@ -2,6 +2,8 @@ package helm
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -11,9 +13,9 @@ import (
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
-const (
-	repositoryCache  = "/tmp/.helmcache"
-	repositoryConfig = "/tmp/.helmrepo"
+var (
+	repositoryCache  = filepath.Join(os.TempDir(), ".helmcache")
+	repositoryConfig = filepath.Join(os.TempDir(), ".helmrepo")
 )
 
 // Helm is helm implementation

--- a/pkg/util/helm/local.go
+++ b/pkg/util/helm/local.go
@@ -2,9 +2,10 @@ package helm
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/devstream-io/devstream/pkg/util/file"
 
 	"github.com/devstream-io/devstream/pkg/util/log"
 	"github.com/devstream-io/devstream/pkg/util/md5"
@@ -61,41 +62,5 @@ func cacheChartPackage(chartPath string) error {
 	if err = os.MkdirAll(repositoryCache, 0755); err != nil {
 		return err
 	}
-	return copyFile(chartPath, dFilePath)
-}
-
-func copyFile(srcFile, dstFile string) (err error) {
-	// prepare source file
-	sFile, err := os.Open(srcFile)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if closeErr := sFile.Close(); closeErr != nil {
-			log.Errorf("Failed to close file %s: %s", srcFile, closeErr)
-			if err == nil {
-				err = closeErr
-			}
-		}
-	}()
-
-	// create destination file
-	dFile, err := os.Create(dstFile)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if closeErr := dFile.Close(); closeErr != nil {
-			log.Errorf("Failed to close file %s: %s", dstFile, closeErr)
-			if err == nil {
-				err = closeErr
-			}
-		}
-	}()
-
-	// copy and sync
-	if _, err = io.Copy(dFile, sFile); err != nil {
-		return nil
-	}
-	return dFile.Sync()
+	return file.CopyFile(chartPath, dFilePath)
 }

--- a/pkg/util/helm/local.go
+++ b/pkg/util/helm/local.go
@@ -1,0 +1,106 @@
+package helm
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/devstream-io/devstream/pkg/util/log"
+	"github.com/devstream-io/devstream/pkg/util/md5"
+)
+
+func cacheChartPackage(chartPath string) error {
+	if chartPath == "" {
+		log.Debugf("The option chartPath == \"\".")
+		return nil
+	}
+
+	// source file checks
+	sFile, err := os.Stat(chartPath)
+	if err != nil {
+		return fmt.Errorf("chart <%s> doesn't exist", chartPath)
+	}
+	if !sFile.Mode().IsRegular() {
+		return fmt.Errorf("the chart file <%s> is non-regular (%q)", chartPath, sFile.Mode().String())
+	}
+
+	// destination chart path checks
+	dFilePath := filepath.Join(repositoryCache, chartPath)
+	log.Debugf("The destination chart path is <%s>.", dFilePath)
+	dFile, err := os.Stat(dFilePath)
+	if err != nil { // return err if err != nil and err != "NotExist"
+		if !os.IsNotExist(err) {
+			log.Errorf("Got error: %s.", err)
+			return err
+		}
+	} else { // err == nil -> file exists -> check if the source file equals destination file
+		if !(dFile.Mode().IsRegular()) {
+			err = fmt.Errorf("the destination file <%s> is non-regular (%q)", dFilePath, dFile.Mode().String())
+			log.Errorf("Got error: %s.", err)
+			return err
+		}
+		if os.SameFile(sFile, dFile) {
+			log.Debugf("The source chart package and destination chart package are same.")
+			return nil
+		}
+		// check md5
+		equal, err := md5.FilesMD5Equal(chartPath, dFilePath)
+		if err != nil {
+			log.Errorf("Got error: %s.", err)
+			return err
+		}
+		if equal {
+			log.Infof("The chart package already exists in the cache directory.")
+			return nil
+		}
+		// remove the destination file if its name equals to source file but their contents don't equal
+		if err = os.RemoveAll(dFilePath); err != nil {
+			log.Errorf("Got error: %s.", err)
+			return err
+		}
+	}
+
+	// destination chart path is empty, then create it.
+	log.Debugf("Prepare to copy <%s> to <%s>.", chartPath, dFilePath)
+	if err = os.MkdirAll(repositoryCache, 0755); err != nil {
+		return err
+	}
+	return copyFile(chartPath, dFilePath)
+}
+
+func copyFile(srcFile, dstFile string) (err error) {
+	// prepare source file
+	sFile, err := os.Open(srcFile)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := sFile.Close(); closeErr != nil {
+			log.Errorf("Failed to close file %s: %s", srcFile, closeErr)
+			if err == nil {
+				err = closeErr
+			}
+		}
+	}()
+
+	// create destination file
+	dFile, err := os.Create(dstFile)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := dFile.Close(); closeErr != nil {
+			log.Errorf("Failed to close file %s: %s", dstFile, closeErr)
+			if err == nil {
+				err = closeErr
+			}
+		}
+	}()
+
+	// copy and sync
+	if _, err = io.Copy(dFile, sFile); err != nil {
+		return nil
+	}
+	return dFile.Sync()
+}

--- a/pkg/util/helm/local.go
+++ b/pkg/util/helm/local.go
@@ -31,14 +31,11 @@ func cacheChartPackage(chartPath string) error {
 	dFile, err := os.Stat(dFilePath)
 	if err != nil { // return err if err != nil and err != "NotExist"
 		if !os.IsNotExist(err) {
-			log.Errorf("Got error: %s.", err)
-			return err
+			return fmt.Errorf("stat file failed: %s.", err)
 		}
 	} else { // err == nil -> file exists -> check if the source file equals destination file
 		if !(dFile.Mode().IsRegular()) {
-			err = fmt.Errorf("the destination file <%s> is non-regular (%q)", dFilePath, dFile.Mode().String())
-			log.Errorf("Got error: %s.", err)
-			return err
+			return fmt.Errorf("the destination file <%s> is non-regular (%q)", dFilePath, dFile.Mode().String())
 		}
 		if os.SameFile(sFile, dFile) {
 			log.Debugf("The source chart package and destination chart package are same.")
@@ -47,8 +44,7 @@ func cacheChartPackage(chartPath string) error {
 		// check md5
 		equal, err := md5.FilesMD5Equal(chartPath, dFilePath)
 		if err != nil {
-			log.Errorf("Got error: %s.", err)
-			return err
+			return fmt.Errorf("calc md5 failed: %s.", err)
 		}
 		if equal {
 			log.Infof("The chart package already exists in the cache directory.")
@@ -56,8 +52,7 @@ func cacheChartPackage(chartPath string) error {
 		}
 		// remove the destination file if its name equals to source file but their contents don't equal
 		if err = os.RemoveAll(dFilePath); err != nil {
-			log.Errorf("Got error: %s.", err)
-			return err
+			return fmt.Errorf("remove destination file failed: %s.", err)
 		}
 	}
 

--- a/pkg/util/helm/param.go
+++ b/pkg/util/helm/param.go
@@ -21,7 +21,7 @@ type Repo struct {
 type Chart struct {
 	// if ChartPath equals to "", then Repo.Name and Repo.URL must be set
 	ChartPath   string `mapstructure:"chartPath"`
-	ChartName   string `validate:"required" mapstructure:"chartName"`
+	ChartName   string `mapstructure:"chartName"`
 	Version     string `mapstructure:"version"`
 	ReleaseName string `mapstructure:"releaseName"`
 	Namespace   string `mapstructure:"namespace"`

--- a/pkg/util/helm/param.go
+++ b/pkg/util/helm/param.go
@@ -11,13 +11,16 @@ type HelmParam struct {
 // Repo is the struct containing details of a git repository.
 // TODO(daniel-hutao): make the Repo equals to repo.Entry
 type Repo struct {
-	Name string `validate:"required" mapstructure:"name"`
-	URL  string `validate:"required" mapstructure:"url"`
+	// if Name or URL equals to "", then Chart.ChartPath must be set
+	Name string `mapstructure:"name"`
+	URL  string `mapstructure:"url"`
 }
 
 // Chart is the struct containing details of a helm chart.
 // TODO(daniel-hutao): make the Chart equals to helmclient.ChartSpec
 type Chart struct {
+	// if ChartPath equals to "", then Repo.Name and Repo.URL must be set
+	ChartPath   string `mapstructure:"chartPath"`
 	ChartName   string `validate:"required" mapstructure:"chartName"`
 	Version     string `mapstructure:"version"`
 	ReleaseName string `mapstructure:"releaseName"`

--- a/pkg/util/helm/param.go
+++ b/pkg/util/helm/param.go
@@ -18,16 +18,16 @@ type Repo struct {
 // Chart is the struct containing details of a helm chart.
 // TODO(daniel-hutao): make the Chart equals to helmclient.ChartSpec
 type Chart struct {
-	ChartName   string `validate:"required" mapstructure:"chart_name"`
+	ChartName   string `validate:"required" mapstructure:"chartName"`
 	Version     string `mapstructure:"version"`
-	ReleaseName string `mapstructure:"release_name"`
+	ReleaseName string `mapstructure:"releaseName"`
 	Namespace   string `mapstructure:"namespace"`
 	Wait        *bool  `mapstructure:"wait"`
 	Timeout     string `mapstructure:"timeout"` // such as "1.5h" or "2h45m", valid time units are "s", "m", "h"
 	UpgradeCRDs *bool  `mapstructure:"upgradeCRDs"`
 	// ValuesYaml is the values.yaml content.
 	// use string instead of map[string]interface{}
-	ValuesYaml string `validate:"omitempty,yaml" mapstructure:"values_yaml"`
+	ValuesYaml string `validate:"omitempty,yaml" mapstructure:"valuesYaml"`
 }
 
 func (repo *Repo) FillDefaultValue(defaultRepo *Repo) {

--- a/pkg/util/helm/validation.go
+++ b/pkg/util/helm/validation.go
@@ -1,8 +1,17 @@
 package helm
 
-import "github.com/devstream-io/devstream/pkg/util/validator"
+import (
+	"fmt"
+
+	"github.com/devstream-io/devstream/pkg/util/validator"
+)
 
 // Validate validates helm param
 func Validate(param *HelmParam) []error {
-	return validator.Struct(param)
+	var retErrs = validator.Struct(param)
+	if param.Chart.ChartPath == "" && (param.Repo.Name == "" || param.Repo.URL == "") {
+		err := fmt.Errorf("if chartPath == \"\", then the repo.Name & repo.URL must be set")
+		retErrs = append(retErrs, err)
+	}
+	return retErrs
 }

--- a/pkg/util/helm/validation.go
+++ b/pkg/util/helm/validation.go
@@ -9,9 +9,11 @@ import (
 // Validate validates helm param
 func Validate(param *HelmParam) []error {
 	var retErrs = validator.Struct(param)
-	if param.Chart.ChartPath == "" && (param.Repo.Name == "" || param.Repo.URL == "") {
-		err := fmt.Errorf("if chartPath == \"\", then the repo.Name & repo.URL must be set")
+
+	if param.Chart.ChartPath == "" && (param.Repo.Name == "" || param.Repo.URL == "" || param.Chart.ChartName == "") {
+		err := fmt.Errorf("if chartPath == \"\", then the repo.Name & repo.URL & chart.chartName must be set")
 		retErrs = append(retErrs, err)
 	}
+
 	return retErrs
 }

--- a/pkg/util/md5/md5.go
+++ b/pkg/util/md5/md5.go
@@ -24,3 +24,17 @@ func FileMatchesMD5(fileName, md5FileName string) (bool, error) {
 
 	return currentPlugInMD5 == md5Content, nil
 }
+
+func FilesMD5Equal(file1, file2 string) (bool, error) {
+	file1MD5, err := CalcFileMD5(file1)
+	if err != nil {
+		return false, err
+	}
+
+	file2MD5, err := CalcFileMD5(file1)
+	if err != nil {
+		return false, err
+	}
+
+	return file1MD5 == file2MD5, nil
+}

--- a/test/e2e/yaml/e2e-test-local.yaml
+++ b/test/e2e/yaml/e2e-test-local.yaml
@@ -57,6 +57,7 @@ tools:
       name: argo
       url: https://argoproj.github.io/argo-helm
     chart:
+      chartPath: ""
       chartName: argo/argo-cd
       releaseName: argocd
       namespace: [[ argocdNameSpace ]]

--- a/test/e2e/yaml/e2e-test-local.yaml
+++ b/test/e2e/yaml/e2e-test-local.yaml
@@ -57,8 +57,8 @@ tools:
       name: argo
       url: https://argoproj.github.io/argo-helm
     chart:
-      chart_name: argo/argo-cd
-      release_name: argocd
+      chartName: argo/argo-cd
+      releaseName: argocd
       namespace: [[ argocdNameSpace ]]
       wait: true
       timeout: [[ argocdDeployTimeout ]]

--- a/test/e2e/yaml/e2e-tools.yaml
+++ b/test/e2e/yaml/e2e-tools.yaml
@@ -41,6 +41,7 @@ tools:
         name: argo
         url: https://argoproj.github.io/argo-helm
       chart:
+        chartPath: ""
         chartName: argo/argo-cd
         releaseName: argocd
         namespace: [[ argocdNameSpace ]]

--- a/test/e2e/yaml/e2e-tools.yaml
+++ b/test/e2e/yaml/e2e-tools.yaml
@@ -41,8 +41,8 @@ tools:
         name: argo
         url: https://argoproj.github.io/argo-helm
       chart:
-        chart_name: argo/argo-cd
-        release_name: argocd
+        chartName: argo/argo-cd
+        releaseName: argocd
         namespace: [[ argocdNameSpace ]]
         wait: true
         timeout: [[ argocdDeployTimeout ]]


### PR DESCRIPTION
## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

New feat with helm chart local installation

## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->

#1084 

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->

- Apply without Internet

![image](https://user-images.githubusercontent.com/18692628/190139179-dc548a1f-68a4-4d2c-9447-87339521afe6.png)

- Config file was used

```yaml
---
# core config
varFile: "" # If not empty, use the specified external variables config file
toolFile: "" # If not empty, use the specified external tools config file
pluginDir: "~/.devstream/plugins"
state: # state config, backend can be local or s3
  backend: local
  options:
    stateFile: devstream.state

---
tools:
# name of the tool
- name: jenkins
  # id of the tool instance
  instanceID: default
  # format: name.instanceID; If specified, dtm will make sure the dependency is applied first before handling this tool.
  dependsOn: [ ]
  # options for the plugin
  options:
    # Helm repo information
    repo:
      # name of the Helm repo
      name: jenkins
      # url of the Helm repo
      url: https://charts.jenkins.io
    # Helm chart information
    chart:
      # local path of the chart; if chartPath != "", repo.name and repo.url will be ignored. e.g. "foo.tgz", "./foo.tgz", "/tmp/foo.tgz"
      chartPath: "./jenkins-4.2.1.tgz"
      # name of the chart
      chartName: jenkins/jenkins
      # k8s namespace where jenkins will be installed
      namespace: jenkins
      # whether to wait for the release to be deployed or not
      wait: true
      # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 5m0s
      timeout: 5m
      # whether to perform a CRD upgrade during installation
      upgradeCRDs: true
      # custom configuration. You can refer to [Jenkins values.yaml](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml)
      valuesYaml: |
        persistence:
          storageClass: ""
        serviceAccount:
          create: true
          name: jenkins
        controller:
          adminUser: "admin"
          adminPassword: "changeme"
          serviceType: NodePort
          nodePort: 32000
```