### PR TITLE
feat: use `dtm init --download-only` to download specify plugins from flags

### DIFF
--- a/cmd/devstream/init.go
+++ b/cmd/devstream/init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -24,70 +25,117 @@ var initCMD = &cobra.Command{
 }
 
 var (
-	downloadAll bool   // download all plugins which dtm supports
-	initOS      string // download plugins for specific os
-	initArch    string // download plugins for specific arch
+	downloadOnly      bool     // download plugins only, from command line flags
+	downloadAll       bool     // download all plugins
+	pluginsToDownload []string // download specific plugins
+	initOS            string   // download plugins for specific os
+	initArch          string   // download plugins for specific arch
 )
 
 func initCMDFunc(_ *cobra.Command, _ []string) {
 	if version.Dev {
-		log.Errorf("Dev version plugins can't be downloaded from the remote plugin repo; please run `make build-plugin.PLUGIN_NAME` to build them locally.")
-		return
+		log.Fatalf("Dev version plugins can't be downloaded from the remote plugin repo; please run `make build-plugin.PLUGIN_NAME` to build them locally.")
 	}
 
-	var tools []configmanager.Tool
+	var (
+		realPluginDir string
+		tools         []configmanager.Tool
+		err           error
+	)
 
-	switch downloadAll {
+	switch downloadOnly {
+	// download plugins according to the config file
 	case false:
-		// download plugins according to the config file
-		cfg, err := configmanager.NewManager(configFile).LoadConfig()
-		if err != nil {
-			log.Errorf("Error: %s.", err)
-			return
-		}
-
-		// combine plugin dir from config file and flag
-		if err := file.SetPluginDir(cfg.PluginDir); err != nil {
-			log.Errorf("Error: %s.", err)
-		}
-
-		tools = cfg.Tools
-		pluginDir = viper.GetString(pluginDirFlagName)
+		tools, realPluginDir, err = GetPluginsAndPluginDirFromConfig()
+	// download plugins from flags
 	case true:
-		// download all plugins
-		if initOS == "" || initArch == "" {
-			log.Errorf("Once you use the --all flag, you must specify the --os and --arch flags.")
-			return
-		}
-		// build the plugin list
-		pluginsName := list.PluginsNameSlice()
-		for _, pluginName := range pluginsName {
-			tools = append(tools, configmanager.Tool{Name: pluginName})
-		}
-
-		var err error
-		pluginDir = viper.GetString(pluginDirFlagName)
-		pluginDir, err = file.HandlePathWithHome(pluginDir)
-		if err != nil {
-			log.Errorf("Error: %s.", err)
-		}
+		tools, realPluginDir, err = GetPluginsAndPluginDirFromFlags()
 	}
 
-	if err := pluginmanager.DownloadPlugins(tools, pluginDir, initOS, initArch); err != nil {
-		log.Errorf("Error: %s.", err)
-		return
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := pluginmanager.DownloadPlugins(tools, realPluginDir, initOS, initArch); err != nil {
+		log.Fatal(err)
 	}
 
 	fmt.Println()
 	log.Success("Initialize finished.")
 }
 
+func GetPluginsAndPluginDirFromConfig() (tools []configmanager.Tool, pluginName string, err error) {
+	cfg, err := configmanager.NewManager(configFile).LoadConfig()
+	if err != nil {
+		return nil, "", err
+	}
+
+	// combine plugin dir from config file and flag
+	if err := file.SetPluginDir(cfg.PluginDir); err != nil {
+		return nil, "", err
+	}
+
+	return cfg.Tools, viper.GetString(pluginDirFlagName), nil
+}
+
+func GetPluginsAndPluginDirFromFlags() (tools []configmanager.Tool, pluginName string, err error) {
+	// 1. get plugins from flags
+	var pluginsName []string
+	switch downloadAll {
+	// download all plugins
+	case true:
+		pluginsName = list.PluginsNameSlice()
+	// download specific plugins
+	case false:
+		log.Info(pluginsToDownload)
+		for _, pluginName := range pluginsToDownload {
+			if p := strings.ToLower(strings.TrimSpace(pluginName)); p != "" {
+				pluginsName = append(pluginsName, p)
+			}
+		}
+		// check if plugins to download are supported by dtm
+		for _, plugin := range pluginsToDownload {
+			if _, ok := list.PluginNamesMap()[plugin]; !ok {
+				return nil, "", fmt.Errorf("plugin %s is not supported by dtm", plugin)
+			}
+		}
+	}
+
+	if len(pluginsName) == 0 {
+		log.Errorf("Please use --plugins to specify plugins to download or use --all to download all plugins.")
+	}
+	log.Debugf("plugins to download: %v", pluginsName)
+
+	if initOS == "" || initArch == "" {
+		return nil, "", fmt.Errorf("once you use the --all flag, you must specify the --os and --arch flags")
+	}
+
+	// build the plugin list
+	for _, pluginName := range pluginsName {
+		tools = append(tools, configmanager.Tool{Name: pluginName})
+	}
+
+	// 2. handle plugin dir
+	pluginDir = viper.GetString(pluginDirFlagName)
+	pluginDir, err = file.HandlePathWithHome(pluginDir)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return tools, pluginDir, nil
+}
+
 func init() {
+	// flags for init from config file
 	initCMD.Flags().StringVarP(&configFile, configFlagName, "f", "config.yaml", "config file")
 	initCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", "", "plugins directory")
-	initCMD.Flags().BoolVarP(&downloadAll, "all", "a", false, "download all plugins which dtm supports")
-	initCMD.Flags().StringVarP(&initOS, "os", "", runtime.GOOS, "download plugins for specific os")
-	initCMD.Flags().StringVarP(&initArch, "arch", "", runtime.GOARCH, "download plugins for specific arch")
+
+	// downloading specific plugins from flags
+	initCMD.Flags().BoolVar(&downloadOnly, "download-only", false, "download plugins only")
+	initCMD.Flags().StringSliceVarP(&pluginsToDownload, "plugins", "p", []string{}, "plugins to download")
+	initCMD.Flags().BoolVarP(&downloadAll, "all", "a", false, "download all plugins")
+	initCMD.Flags().StringVar(&initOS, "os", runtime.GOOS, "download plugins for specific os")
+	initCMD.Flags().StringVar(&initArch, "arch", runtime.GOARCH, "download plugins for specific arch")
 
 	completion.FlagFilenameCompletion(initCMD, configFlagName)
 	completion.FlagDirnameCompletion(initCMD, pluginDirFlagName)

--- a/cmd/devstream/init.go
+++ b/cmd/devstream/init.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
+	"github.com/devstream-io/devstream/cmd/devstream/list"
 	"github.com/devstream-io/devstream/internal/pkg/completion"
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
 	"github.com/devstream-io/devstream/internal/pkg/pluginmanager"
@@ -20,23 +23,57 @@ var initCMD = &cobra.Command{
 	Run:   initCMDFunc,
 }
 
+var (
+	downloadAll bool   // download all plugins which dtm supports
+	initOS      string // download plugins for specific os
+	initArch    string // download plugins for specific arch
+)
+
 func initCMDFunc(_ *cobra.Command, _ []string) {
-	cfg, err := configmanager.NewManager(configFile).LoadConfig()
-	if err != nil {
-		log.Errorf("Error: %s.", err)
-		return
-	}
-
-	if err := file.SetPluginDir(cfg.PluginDir); err != nil {
-		log.Errorf("Error: %s.", err)
-	}
-
 	if version.Dev {
 		log.Errorf("Dev version plugins can't be downloaded from the remote plugin repo; please run `make build-plugin.PLUGIN_NAME` to build them locally.")
 		return
 	}
 
-	if err = pluginmanager.DownloadPlugins(cfg); err != nil {
+	var tools []configmanager.Tool
+
+	switch downloadAll {
+	case false:
+		// download plugins according to the config file
+		cfg, err := configmanager.NewManager(configFile).LoadConfig()
+		if err != nil {
+			log.Errorf("Error: %s.", err)
+			return
+		}
+
+		// combine plugin dir from config file and flag
+		if err := file.SetPluginDir(cfg.PluginDir); err != nil {
+			log.Errorf("Error: %s.", err)
+		}
+
+		tools = cfg.Tools
+		pluginDir = viper.GetString(pluginDirFlagName)
+	case true:
+		// download all plugins
+		if initOS == "" || initArch == "" {
+			log.Errorf("Once you use the --all flag, you must specify the --os and --arch flags.")
+			return
+		}
+		// build the plugin list
+		pluginsName := list.PluginsNameSlice()
+		for _, pluginName := range pluginsName {
+			tools = append(tools, configmanager.Tool{Name: pluginName})
+		}
+
+		var err error
+		pluginDir = viper.GetString(pluginDirFlagName)
+		pluginDir, err = file.HandlePathWithHome(pluginDir)
+		if err != nil {
+			log.Errorf("Error: %s.", err)
+		}
+	}
+
+	if err := pluginmanager.DownloadPlugins(tools, pluginDir, initOS, initArch); err != nil {
 		log.Errorf("Error: %s.", err)
 		return
 	}
@@ -48,6 +85,9 @@ func initCMDFunc(_ *cobra.Command, _ []string) {
 func init() {
 	initCMD.Flags().StringVarP(&configFile, configFlagName, "f", "config.yaml", "config file")
 	initCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", "", "plugins directory")
+	initCMD.Flags().BoolVarP(&downloadAll, "all", "a", false, "download all plugins which dtm supports")
+	initCMD.Flags().StringVarP(&initOS, "os", "", runtime.GOOS, "download plugins for specific os")
+	initCMD.Flags().StringVarP(&initArch, "arch", "", runtime.GOARCH, "download plugins for specific arch")
 
 	completion.FlagFilenameCompletion(initCMD, configFlagName)
 	completion.FlagDirnameCompletion(initCMD, pluginDirFlagName)

--- a/cmd/devstream/init.go
+++ b/cmd/devstream/init.go
@@ -43,13 +43,12 @@ func initCMDFunc(_ *cobra.Command, _ []string) {
 		err           error
 	)
 
-	switch downloadOnly {
-	// download plugins according to the config file
-	case false:
-		tools, realPluginDir, err = GetPluginsAndPluginDirFromConfig()
-	// download plugins from flags
-	case true:
+	if downloadOnly {
+		// download plugins from flags
 		tools, realPluginDir, err = GetPluginsAndPluginDirFromFlags()
+	} else {
+		// download plugins according to the config file
+		tools, realPluginDir, err = GetPluginsAndPluginDirFromConfig()
 	}
 
 	if err != nil {
@@ -132,7 +131,7 @@ func init() {
 
 	// downloading specific plugins from flags
 	initCMD.Flags().BoolVar(&downloadOnly, "download-only", false, "download plugins only")
-	initCMD.Flags().StringSliceVarP(&pluginsToDownload, "plugins", "p", []string{}, "plugins to download")
+	initCMD.Flags().StringSliceVarP(&pluginsToDownload, "plugins", "p", []string{}, "the plugins to be downloaded")
 	initCMD.Flags().BoolVarP(&downloadAll, "all", "a", false, "download all plugins")
 	initCMD.Flags().StringVar(&initOS, "os", runtime.GOOS, "download plugins for specific os")
 	initCMD.Flags().StringVar(&initArch, "arch", runtime.GOARCH, "download plugins for specific arch")

--- a/cmd/devstream/init.go
+++ b/cmd/devstream/init.go
@@ -80,13 +80,11 @@ func GetPluginsAndPluginDirFromConfig() (tools []configmanager.Tool, pluginName 
 func GetPluginsAndPluginDirFromFlags() (tools []configmanager.Tool, pluginName string, err error) {
 	// 1. get plugins from flags
 	var pluginsName []string
-	switch downloadAll {
-	// download all plugins
-	case true:
+	if downloadAll {
+		// download all plugins
 		pluginsName = list.PluginsNameSlice()
-	// download specific plugins
-	case false:
-		log.Info(pluginsToDownload)
+	} else {
+		// download specific plugins
 		for _, pluginName := range pluginsToDownload {
 			if p := strings.ToLower(strings.TrimSpace(pluginName)); p != "" {
 				pluginsName = append(pluginsName, p)
@@ -95,7 +93,7 @@ func GetPluginsAndPluginDirFromFlags() (tools []configmanager.Tool, pluginName s
 		// check if plugins to download are supported by dtm
 		for _, plugin := range pluginsToDownload {
 			if _, ok := list.PluginNamesMap()[plugin]; !ok {
-				return nil, "", fmt.Errorf("plugin %s is not supported by dtm", plugin)
+				return nil, "", fmt.Errorf("Plugin %s is not supported by dtm", plugin)
 			}
 		}
 	}
@@ -106,8 +104,10 @@ func GetPluginsAndPluginDirFromFlags() (tools []configmanager.Tool, pluginName s
 	log.Debugf("plugins to download: %v", pluginsName)
 
 	if initOS == "" || initArch == "" {
-		return nil, "", fmt.Errorf("once you use the --all flag, you must specify the --os and --arch flags")
+		return nil, "", fmt.Errorf("Once you use the --all flag, you must specify the --os and --arch flags")
 	}
+
+	log.Infof("Plugins to download: %v", pluginsName)
 
 	// build the plugin list
 	for _, pluginName := range pluginsName {

--- a/cmd/devstream/list/list.go
+++ b/cmd/devstream/list/list.go
@@ -16,10 +16,8 @@ var PluginsName string
 
 // List all plugins name
 func List(pluginFilter string) {
-	listPluginsName := strings.Fields(PluginsName)
 	r, _ := regexp.Compile(pluginFilter)
-	sort.Strings(listPluginsName)
-	for _, pluginName := range listPluginsName {
+	for _, pluginName := range PluginsNameSlice() {
 		if r.Match([]byte(pluginName)) {
 			fmt.Println(pluginName)
 		}

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -6,29 +6,47 @@ For config file, tool file, see the [config](../core-concepts/config.md) section
 
 ## Downloading Plugins
 
+There are two ways to download plugins:
+1. from config file: download plugins according to the tool file in the config
+2. from command line: download plugins according to the command line arguments
+
+### Downloading Plugins from Config File
+
+command: `dtm init` or `dtm init -f <config file>`. The default config file path is `config.yaml`.
+
 Before v0.5.0 (included,) `dtm` releases plugins to the GitHub releases page.
 
 When you run `dtm init`, `dtm` will decide which plugins exist and which do not (based on the config file/tool file,) then download the plugins that are needed but don't exist locally from the GitHub release page.
 
 After v0.5.0 (feature work in progress now), `dtm` will release plugins to an AWS S3 bucket. When running `dtm init`, it will download plugins from the AWS S3 bucket instead (through Cloudflare CDN.)
 
+### Downloading Plugins from Command Line
+
+This can be used to pre-download the plugin to use dtm in an offline environment.
+
+command: 
+
+1. download specify plugins. e.g. `dtm init --download-only --plugins=repo-scaffolding,githubactions-golang -d=.devstream/plugins`
+2. download all plugins. e.g. `dtm init --download-only --all -d=.devstream/plugins`
+
+
 ## Flags
 
-`dtm init` has the following flags:
-
-| Short | Long          | Default              | Description                                            |
-|-------|---------------|----------------------|--------------------------------------------------------|
-| -f    | --config-file | `"config.yaml"`      | The config file to use                                 |
-| -d    | --plugin-dir  | `"~/.dtm/plugins"`   | The directory to store plugins                         |
-| -a    | --all         | `false`              | Download all plugins rather than from the config file. |
-|       | --os          | OS of this machine   | The OS to download plugins for.                        |
-|       | --arch        | Arch of this machine | The architecture to download plugins for.              |
+| Short | Long            | Default              | Description                                                                  |
+|-------|-----------------|----------------------|------------------------------------------------------------------------------|
+| -f    | --config-file   | `"config.yaml"`      | The config file to use                                                       |
+| -d    | --plugin-dir    | `"~/.dtm/plugins"`   | The directory to store plugins                                               |
+|       | --download-only | `false`              | Download plugins only                                                        |
+| -p    | --plugins       | `""`                 | Plugins to download, seperated with ",", should be used with --download-only |
+| -a    | --all           | `false`              | Download all plugins, should be used with --download-only                    |
+|       | --os            | OS of this machine   | The OS to download plugins for.                                              |
+|       | --arch          | Arch of this machine | The architecture to download plugins for.                                    |
 
 _Note: You could use `dtm init --all --os=DestinyOS --arch=DestinyArch -d=PLUGIN_DIR` to download all plugins and use dtm offline._
 
 ## Init Logic
 
-- Based on the config file and the tool file, decide which plugins are required.
+- Based on the config file and the tool file or command line flags, decide which plugins are required.
 - If the plugin exists locally and the version is correct, do nothing.
 - If the plugin is missing, download the plugin.
 - After downloading, `dtm` also downloads the md5 value of that plugin and compares them. If matched, succeed.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -12,6 +12,20 @@ When you run `dtm init`, `dtm` will decide which plugins exist and which do not 
 
 After v0.5.0 (feature work in progress now), `dtm` will release plugins to an AWS S3 bucket. When running `dtm init`, it will download plugins from the AWS S3 bucket instead (through Cloudflare CDN.)
 
+## Flags
+
+`dtm init` has the following flags:
+
+| Short | Long          | Default              | Description                                            |
+|-------|---------------|----------------------|--------------------------------------------------------|
+| -f    | --config-file | `"config.yaml"`      | The config file to use                                 |
+| -d    | --plugin-dir  | `"~/.dtm/plugins"`   | The directory to store plugins                         |
+| -a    | --all         | `false`              | Download all plugins rather than from the config file. |
+|       | --os          | OS of this machine   | The OS to download plugins for.                        |
+|       | --arch        | Arch of this machine | The architecture to download plugins for.              |
+
+_Note: You could use `dtm init --all --os=DestinyOS --arch=DestinyArch -d=PLUGIN_DIR` to download all plugins and use dtm offline._
+
 ## Init Logic
 
 - Based on the config file and the tool file, decide which plugins are required.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -32,15 +32,15 @@ command:
 
 ## Flags
 
-| Short | Long            | Default              | Description                                                                  |
-|-------|-----------------|----------------------|------------------------------------------------------------------------------|
-| -f    | --config-file   | `"config.yaml"`      | The config file to use                                                       |
-| -d    | --plugin-dir    | `"~/.dtm/plugins"`   | The directory to store plugins                                               |
-|       | --download-only | `false`              | Download plugins only                                                        |
-| -p    | --plugins       | `""`                 | Plugins to download, seperated with ",", should be used with --download-only |
-| -a    | --all           | `false`              | Download all plugins, should be used with --download-only                    |
-|       | --os            | OS of this machine   | The OS to download plugins for.                                              |
-|       | --arch          | Arch of this machine | The architecture to download plugins for.                                    |
+| Short | Long            | Default              | Description                                                                       |
+|-------|-----------------|----------------------|-----------------------------------------------------------------------------------|
+| -f    | --config-file   | `"config.yaml"`      | The config file to use                                                            |
+| -d    | --plugin-dir    | `"~/.dtm/plugins"`   | The directory to store plugins                                                    |
+|       | --download-only | `false`              | Download plugins only                                                             |
+| -p    | --plugins       | `""`                 | Plugins to be downloaded, seperated with ",", should be used with --download-only |
+| -a    | --all           | `false`              | Download all plugins, should be used with --download-only                         |
+|       | --os            | OS of this machine   | The OS to download plugins for.                                                   |
+|       | --arch          | Arch of this machine | The architecture to download plugins for.                                         |
 
 _Note: You could use `dtm init --all --os=DestinyOS --arch=DestinyArch -d=PLUGIN_DIR` to download all plugins and use dtm offline._
 

--- a/internal/pkg/configmanager/configmanager.go
+++ b/internal/pkg/configmanager/configmanager.go
@@ -264,14 +264,23 @@ func (m *Manager) checkConfigType(bytes []byte, configType string) (bool, error)
 func GetPluginName(t *Tool) string {
 	return fmt.Sprintf("%s-%s-%s_%s", t.Name, GOOS, GOARCH, version.Version)
 }
+func GetPluginNameWithOSAndArch(t *Tool, os, arch string) string {
+	return fmt.Sprintf("%s-%s-%s_%s", t.Name, os, arch, version.Version)
+}
 
 // GetPluginFileName creates the file name based on the tool's name and version
 // If the plugin {githubactions 0.0.1}, the generated name will be "githubactions_0.0.1.so"
 func GetPluginFileName(t *Tool) string {
 	return GetPluginName(t) + ".so"
 }
+func GetPluginFileNameWithOSAndArch(t *Tool, os, arch string) string {
+	return GetPluginNameWithOSAndArch(t, os, arch) + ".so"
+}
 
 // GetPluginMD5FileName  If the plugin {githubactions 0.0.1}, the generated name will be "githubactions_0.0.1.md5"
 func GetPluginMD5FileName(t *Tool) string {
 	return GetPluginName(t) + ".md5"
+}
+func GetPluginMD5FileNameWithOSAndArch(t *Tool, os, arch string) string {
+	return GetPluginNameWithOSAndArch(t, os, arch) + ".md5"
 }

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -14,9 +14,7 @@ import (
 	"github.com/devstream-io/devstream/pkg/util/md5"
 )
 
-func DownloadPlugins(conf *configmanager.Config) error {
-	// create plugins dir if not exist
-	pluginDir := viper.GetString("plugin-dir")
+func DownloadPlugins(tools []configmanager.Tool, pluginDir, osName, arch string) error {
 	if pluginDir == "" {
 		return fmt.Errorf(`plugins directory should not be ""`)
 	}
@@ -26,10 +24,10 @@ func DownloadPlugins(conf *configmanager.Config) error {
 	// download all plugins that don't exist locally
 	dc := NewPbDownloadClient(defaultReleaseUrl)
 
-	for _, tool := range conf.Tools {
-		pluginName := configmanager.GetPluginName(&tool)
-		pluginFileName := configmanager.GetPluginFileName(&tool)
-		pluginMD5FileName := configmanager.GetPluginMD5FileName(&tool)
+	for _, tool := range tools {
+		pluginName := configmanager.GetPluginNameWithOSAndArch(&tool, osName, arch)
+		pluginFileName := configmanager.GetPluginFileNameWithOSAndArch(&tool, osName, arch)
+		pluginMD5FileName := configmanager.GetPluginMD5FileNameWithOSAndArch(&tool, osName, arch)
 
 		// a new line to make outputs more beautiful
 		fmt.Println()

--- a/internal/pkg/pluginmanager/manager_test.go
+++ b/internal/pkg/pluginmanager/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -168,7 +169,8 @@ var _ = Describe("MD5", func() {
 		When("pluginDir is Empty", func() {
 			It("should return err", func() {
 				viper.Set("plugin-dir", "")
-				err = DownloadPlugins(config)
+				pluginDir := viper.GetString("plugin-dir")
+				err = DownloadPlugins(config.Tools, pluginDir, runtime.GOOS, runtime.GOARCH)
 				Expect(err).Error().Should(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring("plugins directory should not be "))
 			})

--- a/pkg/util/file/file.go
+++ b/pkg/util/file/file.go
@@ -32,15 +32,15 @@ func GetPluginDir(conf string) (string, error) {
 		return DefaultPluginDir, nil
 	}
 
-	pluginRealDir, err := getRealPath(pluginDir)
+	pluginRealDir, err := HandlePathWithHome(pluginDir)
 	if err != nil {
 		return "", err
 	}
 	return pluginRealDir, nil
 }
 
-// getRealPath deal with "~" in the filePath
-func getRealPath(filePath string) (string, error) {
+// HandlePathWithHome deal with "~" in the filePath
+func HandlePathWithHome(filePath string) (string, error) {
 	if !strings.Contains(filePath, "~") {
 		return filePath, nil
 	}


### PR DESCRIPTION
Signed-off-by: Bird <aflybird0@gmail.com>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
1. use `dtm init --download-only` to download specify plugins from flags.
2. use `--plugins` to specify plugins to download.
3. use `--all` to download all plugins.
4. use `--os` and `--arch` to specify os and arch, the default is os and arch of the machine which executes dtm.

## Related Issues
The first task of #1084.

(We can use quick-start script to download `dtm` and use `dtm init --all --os=DestinyOS --arch=DestinyArch -d=PLUGIN_DIR` to download plugins.

## New Behavior (screenshots if needed)

Comment out this code and test:

<img width="983" alt="image" src="https://user-images.githubusercontent.com/36830265/190920379-82a7fa43-9aa5-4989-b2da-ff63a906c232.png">

<img width="1301" alt="image" src="https://user-images.githubusercontent.com/36830265/190981578-0c1da4dd-0366-4088-8568-c68d1dc8808f.png">

<img width="1411" alt="image" src="https://user-images.githubusercontent.com/36830265/190981647-643ff785-9a48-4ee5-9ad8-a36e860cf26d.png">

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/36830265/190981703-974f0738-b34e-4839-aef7-5151cba319bf.png">






