### PR TITLE
Feat: State Getting Logic Enhancement with DevLake Plugin

### DIFF
--- a/internal/pkg/plugin/devlake/create.go
+++ b/internal/pkg/plugin/devlake/create.go
@@ -15,7 +15,7 @@ func Create(options map[string]interface{}) (map[string]interface{}, error) {
 		},
 		ExecuteOperations:   helm.DefaultCreateOperations,
 		TerminateOperations: helm.DefaultTerminateOperations,
-		GetStateOperation:   helm.GetPluginAllState,
+		GetStateOperation:   genDevLakeState,
 	}
 
 	// Execute all Operations in Operator

--- a/internal/pkg/plugin/devlake/devlake.go
+++ b/internal/pkg/plugin/devlake/devlake.go
@@ -1,10 +1,17 @@
 package devlake
 
 import (
+	"fmt"
+
+	"github.com/devstream-io/devstream/internal/pkg/plugininstaller"
 	"github.com/devstream-io/devstream/internal/pkg/plugininstaller/helm"
+	"github.com/devstream-io/devstream/internal/pkg/statemanager"
 	helmCommon "github.com/devstream-io/devstream/pkg/util/helm"
+	"github.com/devstream-io/devstream/pkg/util/k8s"
 	"github.com/devstream-io/devstream/pkg/util/types"
 )
+
+const DevLakeSvcName = "devlake-lake"
 
 // TODO(daniel-hutao): update the config below after devlake chart released.
 var defaultHelmConfig = helm.Options{
@@ -21,4 +28,49 @@ var defaultHelmConfig = helm.Options{
 		URL:  "https://merico-dev.github.io/devlake-helm-chart",
 		Name: "devlake",
 	},
+}
+
+func genDevLakeState(options plugininstaller.RawOptions) (statemanager.ResourceState, error) {
+	resState, err := helm.GetPluginAllState(options)
+	if err != nil {
+		return nil, err
+	}
+
+	// values.yaml
+	opt, err := helm.NewOptions(options)
+	if err != nil {
+		return nil, err
+	}
+	valuesYaml := opt.GetHelmParam().Chart.ValuesYaml
+	resState["valuesYaml"] = valuesYaml
+
+	// TODO(daniel-hutao): Use Ingress later.
+	ip, err := getDevLakeClusterIP(opt.Chart.Namespace, DevLakeSvcName)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("http://%s:8080", ip)
+	outputs := map[string]interface{}{
+		"devlake_url": url,
+	}
+	resState.SetOutputs(outputs)
+
+	return resState, nil
+}
+
+func getDevLakeClusterIP(namespace, name string) (string, error) {
+	kClient, err := k8s.NewClient()
+	if err != nil {
+		return "", err
+	}
+
+	svc, err := kClient.GetService(namespace, name)
+	if err != nil {
+		return "", err
+	}
+
+	if svc.Spec.ClusterIP == "" {
+		return "", fmt.Errorf("cluster ip is empty")
+	}
+	return svc.Spec.ClusterIP, nil
 }

--- a/internal/pkg/plugin/devlake/read.go
+++ b/internal/pkg/plugin/devlake/read.go
@@ -13,7 +13,7 @@ func Read(options map[string]interface{}) (map[string]interface{}, error) {
 			helm.SetDefaultConfig(&defaultHelmConfig),
 			helm.Validate,
 		},
-		GetStateOperation: helm.GetPluginAllState,
+		GetStateOperation: genDevLakeState,
 	}
 
 	// Execute all Operations in Operator

--- a/internal/pkg/plugin/devlake/update.go
+++ b/internal/pkg/plugin/devlake/update.go
@@ -14,7 +14,7 @@ func Update(options map[string]interface{}) (map[string]interface{}, error) {
 			helm.Validate,
 		},
 		ExecuteOperations: helm.DefaultUpdateOperations,
-		GetStateOperation: helm.GetPluginAllState,
+		GetStateOperation: genDevLakeState,
 	}
 
 	// Execute all Operations in Operator


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

State getting logic enhancement with devlake plugin.

1. Add values.yaml config to DevStream state; 
2. Add *devlake url* to outputs.

## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->

N/A

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->

## Test

- config

```yaml
---
# core config
varFile: "" # If not empty, use the specified external variables config file
toolFile: "" # If not empty, use the specified external tools config file
pluginDir: "~/.devstream/plugins"
state: # state config, backend can be local or s3
  backend: local
  options:
    stateFile: devstream.state

---
tools:
  # name of the tool
  - name: devlake
    # id of the tool instance
    instanceID: default
    # format: name.instanceID; If specified, dtm will make sure the dependency is applied first before handling this tool.
    dependsOn: [ ]
    # options for the plugin
    options:
      # Helm repo information, this section is optional
      repo:
        # name of the Helm repo
        name: devlake
        # url of the Helm repo
        url: https://merico-dev.github.io/devlake-helm-chart
      # Helm chart information
      chart:
        # local path of the chart; if chartPath != "", repo.name and repo.url will be ignored. e.g. "foo.tgz", "./foo.tgz", "/tmp/foo.tgz"
        chartPath: ""
        # name of the chart
        chartName: devlake/devlake
        # version of the chart
        version: ""
        # release name of the chart
        releaseName: devlake
        # k8s namespace where DevLake will be installed
        namespace: devlake
        # whether to wait for the release to be deployed or not
        wait: true
        # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 5m0s
        timeout: 5m
        # whether to perform a CRD upgrade during installation
        upgradeCRDs: true
        # custom configuration (Optional)
        valuesYaml: |
          replicaCount: 1
```

- apply

```sh
./dtm apply -f config-devlake.yaml 
2022-10-12 10:04:43 ℹ [INFO]  Apply started.
2022-10-12 10:04:43 ℹ [INFO]  Using dir </Users/danielhu/.devstream/plugins> to store plugins.
2022-10-12 10:04:43 ℹ [INFO]  Using local backend. State file: devstream.state.
2022-10-12 10:04:43 ℹ [INFO]  Tool (devlake/default) found in config but doesn't exist in the state, will be created.
Continue? [y/n]
Enter a value (Default is n): y

2022-10-12 10:04:44 ℹ [INFO]  Start executing the plan.
2022-10-12 10:04:44 ℹ [INFO]  Changes count: 1.
2022-10-12 10:04:44 ℹ [INFO]  -------------------- [  Processing progress: 1/1.  ] --------------------
2022-10-12 10:04:44 ℹ [INFO]  Processing: (devlake/default) -> Create ...
2022-10-12 10:04:45 ℹ [INFO]  Creating or updating helm chart ...
2022/10/12 10:04:47 creating 9 resource(s)
2022/10/12 10:04:47 beginning wait for 9 resources with timeout of 5m0s
2022/10/12 10:04:47 Deployment is not ready: devlake/devlake-grafana. 0 out of 1 expected pods are ready
...
2022/10/12 10:05:17 StatefulSet is not ready: devlake/devlake-lake. 0 out of 1 expected pods are ready
2022/10/12 10:05:19 release installed successfully: devlake/devlake-0.2.0
2022-10-12 10:05:19 ✔ [SUCCESS]  Tool (devlake/default) Create done.
2022-10-12 10:05:19 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-10-12 10:05:19 ✔ [SUCCESS]  All plugins applied successfully.
2022-10-12 10:05:19 ✔ [SUCCESS]  Apply finished.
```

- state

```yaml
devlake_default:
  name: devlake
  instanceid: default
  dependson: []
  options:
    chart:
      chartName: devlake/devlake
      chartPath: ""
      namespace: devlake
      releaseName: devlake
      timeout: 5m
      upgradeCRDs: true
      valuesYaml: |
        replicaCount: 1
      version: ""
      wait: true
    repo:
      name: devlake
      url: https://merico-dev.github.io/devlake-helm-chart
  resource:
    outputs:
      devlake_url: http://10.110.50.23:8080
    valuesYaml: |
      replicaCount: 1
    workflows: |
      deployment:
        - name: devlake-grafana
          ready: true
        - name: devlake-ui
          ready: true
      statefulset:
        - name: devlake-lake
          ready: true
        - name: devlake-mysql
          ready: true
      daemonset: []
```
