### PR TITLE
feat: use a self-hosted GitHub actions runner that runs as a crd for k8s

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -12,7 +12,7 @@ jobs:
       PLUGINDIR: ~/.devstream/plugins
       GOOS: linux
       GOARCH: amd64
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     steps:
       - run: echo "🐧 This job is now running on a ${{ runner.os }}-${{ runner.arch }} server hosted by GitHub!"
       - name: Checkout

--- a/.github/workflows/cf-ip-monitor.yml
+++ b/.github/workflows/cf-ip-monitor.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, linux, X64 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         go: [1.18.x]
-    runs-on: ${{ matrix.os }}
+    runs-on: [self-hosted, linux, X64]
     name: e2e-test-${{ matrix.os }}
     steps:
       - run: echo "🐧 This job is now running on a ${{ runner.os }}-${{ runner.arch }} server hosted by GitHub!"

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   fossa:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/link-pr.yml
+++ b/.github/workflows/link-pr.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   linkChecker:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   linkChecker:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/lint-commit-message.yml
+++ b/.github/workflows/lint-commit-message.yml
@@ -3,7 +3,7 @@ on: [ push, pull_request ]
 
 jobs:
   lint-commit-message:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   golang-lint:
     name: Golang lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     permissions:
       contents: read
     steps:
@@ -41,7 +41,7 @@ jobs:
         go: [1.18.x]
         include:
           - os: ubuntu-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: [self-hosted, linux, X64]
     name: build-test-${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/update-fig-spec.yml
+++ b/.github/workflows/update-fig-spec.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   update-fig-spec:
     name: Update Fig Spec
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64]
     steps:
       - uses: actions/checkout@v3
       - name: Install Go ${{ env.go-version }}


### PR DESCRIPTION
Signed-off-by: KeHaoKH <hao.ke@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
Use the private github acionts runner to improve packaging speed, except for Mac-related builds. mac-related (including m1 chips and intel chips) builds will not use the private method for now.

## New Behavior (screenshots if needed)

Improved packaging speed, no waiting for GitHub scheduling, and increased concurrency because it runs as an automatically scalable k8s runner
