### PR TITLE
fix: install aws-cli for self-hosted runners

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -49,6 +49,13 @@ jobs:
           cache: true
       - name: Build
         run: make build -j8
+      - name: Install AWS CLI v2
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+          unzip -q /tmp/awscliv2.zip -d /tmp
+          rm /tmp/awscliv2.zip
+          sudo /tmp/aws/install --update
+          rm -rf /tmp/aws/
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@master
         with:


### PR DESCRIPTION
Signed-off-by: KeHaoKH <hao.ke@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
Since we were using the public GitHub actions, aws-cli is already included in the GitHub public runner, but now we are using the self-hosted k8s crd runners, we need to install aws-cli ourselves

## New Behavior (screenshots if needed)
install AWS-Cli for self-hosted runners before config AWS credentials
