### PR TITLE
[fix bug] Execute upgrade in a different path

### DIFF
--- a/internal/pkg/upgrade/upgrade.go
+++ b/internal/pkg/upgrade/upgrade.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/Masterminds/semver"
 
@@ -20,6 +21,7 @@ const (
 	dtmBakFileName = "dtm-bak"
 	dtmOrg         = "devstream-io"
 	dtmRepo        = "devstream"
+	dtmExecute     = "dtm"
 )
 
 // since dtm file name can be changeable by user,so it should be a variable to get current dtm file name
@@ -31,7 +33,9 @@ func Upgrade(continueDirectly bool) error {
 		log.Info("Dtm upgrade: do not support to upgrade dtm in development version.")
 		os.Exit(0)
 	}
-	workDir, err := os.Getwd()
+
+	execDir, err := os.Executable()
+	workDir := strings.Trim(execDir, dtmExecute)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/upgrade/upgrade.go
+++ b/internal/pkg/upgrade/upgrade.go
@@ -21,7 +21,6 @@ const (
 	dtmBakFileName = "dtm-bak"
 	dtmOrg         = "devstream-io"
 	dtmRepo        = "devstream"
-	dtmExecute     = "dtm"
 )
 
 // since dtm file name can be changeable by user,so it should be a variable to get current dtm file name
@@ -34,13 +33,6 @@ func Upgrade(continueDirectly bool) error {
 		os.Exit(0)
 	}
 
-	execDir, err := os.Executable()
-	workDir := strings.Trim(execDir, dtmExecute)
-	if err != nil {
-		return err
-	}
-	log.Debugf("Dtm upgrade: work path is : %v", workDir)
-
 	// get dtm bin file path like `/usr/local/bin/dtm-linux-amd64`
 	binFilePath, err := os.Executable()
 	if err != nil {
@@ -50,6 +42,12 @@ func Upgrade(continueDirectly bool) error {
 	_, dtmFileName = filepath.Split(binFilePath)
 
 	log.Debugf("Dtm upgrade: dtm file name is : %v", dtmFileName)
+
+	workDir := strings.Trim(binFilePath, dtmFileName)
+	if err != nil {
+		return err
+	}
+	log.Debugf("Dtm upgrade: work path is : %v", workDir)
 
 	// 1. Get the latest release version
 	ghOptions := &git.RepoInfo{


### PR DESCRIPTION
issues: https://github.com/devstream-io/devstream/issues/1172

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
<!--

-->

Binary executable file path( /usr/local/bin/):
![avatar](https://cdn.staticaly.com/gh/Shuimo03/PictureBed@main/bin_dtm.2lgxb68c92o0.webp)

exec dtm upgrade other path(/root/devstreamTest)
![avatar](https://cdn.staticaly.com/gh/Shuimo03/PictureBed@main/new_dtm.5futrk60acw0.webp)

## Related Issues
<!--
-->
https://github.com/devstream-io/devstream/issues/1172

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->
