### PR TITLE
Feat: Remove pluginDir Item in Config File

### DIFF
--- a/cmd/devstream/apply.go
+++ b/cmd/devstream/apply.go
@@ -30,7 +30,7 @@ func applyCMDFunc(cmd *cobra.Command, args []string) {
 
 func init() {
 	applyCMD.Flags().StringVarP(&configFilePath, configFlagName, "f", "config.yaml", "config file")
-	applyCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", "", "plugins directory")
+	applyCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", defaultPluginDir, "plugins directory")
 	applyCMD.Flags().BoolVarP(&continueDirectly, "yes", "y", false, "apply directly without confirmation")
 
 	completion.FlagFilenameCompletion(applyCMD, configFlagName)

--- a/cmd/devstream/common.go
+++ b/cmd/devstream/common.go
@@ -9,4 +9,5 @@ var (
 const (
 	configFlagName    = "config-file"
 	pluginDirFlagName = "plugin-dir"
+	defaultPluginDir  = "~/.devstream/plugins"
 )

--- a/cmd/devstream/delete.go
+++ b/cmd/devstream/delete.go
@@ -33,7 +33,7 @@ func deleteCMDFunc(cmd *cobra.Command, args []string) {
 func init() {
 	deleteCMD.Flags().BoolVarP(&isForceDelete, "force", "", false, "force delete by config")
 	deleteCMD.Flags().StringVarP(&configFilePath, configFlagName, "f", "config.yaml", "config file")
-	deleteCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", "", "plugins directory")
+	deleteCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", defaultPluginDir, "plugins directory")
 	deleteCMD.Flags().BoolVarP(&continueDirectly, "yes", "y", false, "delete directly without confirmation")
 
 	completion.FlagFilenameCompletion(deleteCMD, configFlagName)

--- a/cmd/devstream/destroy.go
+++ b/cmd/devstream/destroy.go
@@ -31,7 +31,7 @@ func destroyCMDFunc(cmd *cobra.Command, args []string) {
 func init() {
 	destroyCMD.Flags().BoolVarP(&isForceDestroy, "force", "", false, "force destroy by config")
 	destroyCMD.Flags().StringVarP(&configFilePath, configFlagName, "f", "config.yaml", "config file")
-	destroyCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", "", "plugins directory")
+	destroyCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", defaultPluginDir, "plugins directory")
 	destroyCMD.Flags().BoolVarP(&continueDirectly, "yes", "y", false, "destroy directly without confirmation")
 
 	completion.FlagFilenameCompletion(destroyCMD, configFlagName)

--- a/cmd/devstream/init.go
+++ b/cmd/devstream/init.go
@@ -119,7 +119,7 @@ func GetPluginsFromFlags() (tools []configmanager.Tool, err error) {
 func init() {
 	// flags for init from config file
 	initCMD.Flags().StringVarP(&configFilePath, configFlagName, "f", "config.yaml", "config file")
-	initCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", "~/.devstream/plugins", "plugins directory")
+	initCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", defaultPluginDir, "plugins directory")
 
 	// downloading specific plugins from flags
 	initCMD.Flags().BoolVar(&downloadOnly, "download-only", false, "download plugins only")

--- a/cmd/devstream/show.go
+++ b/cmd/devstream/show.go
@@ -67,7 +67,7 @@ func init() {
 	showStatusCMD.Flags().StringVarP(&plugin, "plugin", "p", "", "specify name with the plugin")
 	showStatusCMD.Flags().StringVarP(&instanceID, "id", "i", "", "specify id with the plugin instance")
 	showStatusCMD.Flags().BoolVarP(&statusAllFlag, "all", "a", false, "show all instances of all plugins status")
-	showStatusCMD.Flags().StringVarP(&pluginDir, "plugin-dir", "d", "", "plugins directory")
+	showStatusCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", defaultPluginDir, "plugins directory")
 	showStatusCMD.Flags().StringVarP(&configFilePath, "config-file", "f", "config.yaml", "config file")
 	completion.FlagPluginsCompletion(showStatusCMD, "plugin")
 }

--- a/cmd/devstream/verify.go
+++ b/cmd/devstream/verify.go
@@ -26,7 +26,7 @@ func verifyCMDFunc(cmd *cobra.Command, args []string) {
 
 func init() {
 	verifyCMD.Flags().StringVarP(&configFilePath, configFlagName, "f", "config.yaml", "config file")
-	verifyCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", "", "plugins directory")
+	verifyCMD.Flags().StringVarP(&pluginDir, pluginDirFlagName, "d", defaultPluginDir, "plugins directory")
 
 	completion.FlagFilenameCompletion(verifyCMD, configFlagName)
 	completion.FlagDirnameCompletion(verifyCMD, pluginDirFlagName)

--- a/docs/best-practices/air-gapped-deployment.zh.md
+++ b/docs/best-practices/air-gapped-deployment.zh.md
@@ -290,7 +290,6 @@ harbor-1.10.0.tgz jenkins-4.2.5.tgz
     ```yaml title="local Backend"
     varFile: "" # If not empty, use the specified external variables config file
     toolFile: "" # If not empty, use the specified external tools config file
-    pluginDir: "./plugins" # If empty, use the default value: ~/.devstream/plugins, or use -d flag to specify a directory
     state: # state config, backend can be local, s3 or k8s
       backend: local
       options:
@@ -302,7 +301,6 @@ harbor-1.10.0.tgz jenkins-4.2.5.tgz
     ```yaml title="k8s Backend"
     varFile: "" # If not empty, use the specified external variables config file
     toolFile: "" # If not empty, use the specified external tools config file
-    pluginDir: "./plugins" # If empty, use the default value: ~/.devstream/plugins, or use -d flag to specify a directory
     state: # state config, backend can be local, s3 or k8s
       backend: k8s
       options:
@@ -330,7 +328,6 @@ harborURL: harbor.example.com
 # core config
 varFile: "" # If not empty, use the specified external variables config file
 toolFile: "" # If not empty, use the specified external tools config file
-pluginDir: "./plugins" # If empty, use the default value: ~/.devstream/plugins, or use -d flag to specify a directory
 state: # state config, backend can be local, s3 or k8s
   backend: k8s
   options:

--- a/docs/core-concepts/config.md
+++ b/docs/core-concepts/config.md
@@ -1,28 +1,25 @@
-# Config
+# DevStream Configuration
 
-Now let's have a look at some config examples.
+DevStream uses YAML files to describe your DevOps toolchain configuration.
 
-TL;DR: see [the last section](./config.md#8-min-config) of this documentation.
+## Main Config File
 
----
+By default, `dtm` tries to use `./config.yaml` (under your current directory) as the main config.
 
-## 1 The Main Config File
+The main config contains three sections:
 
-As mentioned in the overview section, the main config contains many settings, like:
+- `varFile`: the path/to/your/variables file
+- `toolFile`: the path/to/your/tools configuration file
+- `pluginDir`: the path/to/your/plugins directory, default: `~/.devstream/plugins`, or use `-d` flag to specify a directory
+- `state`: configuration of DevStream state. For example, 
 
-- `pluginDir`
-- `state`
-- `varFile`
-- `toolFile`, see [here](./tools-apps.md).
-- `appFile`
-- `templateFile`
+### Example Main Config File
 
-Here's an example of the main config file:
+See the `config.yaml` example below:
 
 ```yaml
 varFile: "./variables.yaml"
 toolFile: "./tools.yaml"
-pluginDir: ""    # empty, use the default value: ~/.devstream/plugins
 appFile: "./apps.yaml"
 templateFile: "./templates.yaml"
 state:           # state config, backend can be "local", "s3", or "k8s"
@@ -31,26 +28,13 @@ state:           # state config, backend can be "local", "s3", or "k8s"
     stateFile: devstream.state
 ```
 
-By default, `dtm` tries to use `./config.yaml` (under your working directory) as the main config.
+### Variables File
 
-You can override the default value with `-f` or `--config-file`. Examples:
+The var file is a YAML file containing key-value pairs.
 
-```shell
-dtm apply -f path/to/your/config.yaml
-dtm apply --config-file path/to/your/config.yaml
-```
+_At the moment, nested/composite values (for example, the value is a list/dictionary) are not supported yet._
 
-No default values are provided for `varFile` and `toolFile`. If `varFile` isn't specified in the main config, `dtm` will not use any var files, even if there is already a file named `variables.yaml` under the current directory. Similarly, if `toolFile` isn't specified in the main config, `dtm` will throw an error, even if there is a `tools.yaml` file under the current directory.
-
----
-
-## 2 Variables File
-
-To not repeat yourself (Don't repeat yourself, DRY, see [here](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself),) we can define some variables in a var file and use the vars in the config file.
-
-The var file is a YAML file containing key-value pairs, which can be nested/composite values (for example, the value is a list/dictionary).
-
-Example:
+See the `variables.yaml` example below:
 
 ```yaml
 githubUsername: daniel-hutao
@@ -59,60 +43,9 @@ defaultBranch: main
 dockerhubUsername: exploitht
 ```
 
-To use these variables in a config file, use the following syntax:
+### Tool File
 
-```yaml
-[[ varNameHere ]]
-```
-
----
-
-## 3 State Config
-
-The `state` section specifies where to store the DevStream state.
-
-### 3.1 Local
-
-```yaml
-# part of the main config file
-state:
-  backend: local
-  options:
-    stateFile: devstream.state
-```
-
-_Note: The `stateFile` under the `options` section is mandatory for the local backend._
-
-### 3.2 Kubernetes
-
-```yaml
-# part of the main config file
-state:
-  backend: k8s
-  options:
-    namespace: devstream # optional, default is "devstream", will be created if not exists
-    configmap: state     # optional, default is "state", will be created if not exists
-```
-
-### 3.3 S3
-
-```yaml
-# part of the main config file
-state:
-  backend: s3
-  options:
-    bucket: devstream-remote-state
-    region: ap-southeast-1
-    key: devstream.state
-```
-
-_Note: the `bucket`, `region`, and `key` under the `options` section are all mandatory fields for the s3 backend._
-
----
-
-## 4 Tool File
-
-The tool file contains a list of tools.
+Tool file contains a list of tools.
 
 The tool file contains:
 
@@ -126,7 +59,7 @@ The tool file contains:
 - Each dictionary (tool) has an optional field which is `options`, which in turn is a dictionary containing parameters for that specific plugin. For plugins' parameters, see the "plugins" section of this document.
 - Each directory (tool) has an optional field which is `dependsOn`. Continue reading for detail about dependencies.
 
-Example:
+See the `tools.yaml` example down below:
 
 ```yaml
 tools:
@@ -157,186 +90,31 @@ tools:
     branch: main
 ```
 
+### State
 
-If you want tool A to be installed before tool B, you can let tool B depend on tool A.
+The `state` section specifies where to store DevStream state. As of now (v0.5.0), we only support local backend.
 
-The syntax for dependency is:
-    
-```yaml
-dependsOn: [ "ToolName.ToolInstanceID" ]
+From v0.6.0 on, we will support both "local" and "s3" backend store the DevStream state.
+
+Read the section [The State Section in the Main Config](./stateconfig.md) for more details.
+
+## Default Values
+
+By default, `dtm` uses `config.yaml` as the main config file.
+
+### Specifying a Main Config File Explicitly 
+
+You can override the default value with `-f` or `--config-file`. Examples:
+
+```shell
+dtm apply -f path/to/your/config.yaml
+dtm apply --config-file path/to/your/config.yaml
 ```
 
-Since `dependsOn` is a list, a tool can have multiple dependencies:
+### No Defaults for varFile and toolFile
 
-```
-dependsOn: [ "ToolName1.ToolInstanceID1", "ToolName2.ToolInstanceID2", "..." ]
-```
+For `varFile` and `toolFile`, no default values are provided.
 
-The example config above shows that the second tool depends on the first.
+If `varFile` isn't specified in the main config, `dtm` will not use any var files, even if there is already a file named `variables.yaml` under the current directory.
 
----
-
-## 5 App File
-
-A full app file looks like the following:
-
-```yaml
-apps:
-- name: service-A
-  spec:
-    language: python
-    framework: django
-  repo:
-    scmType: github
-    owner: devstream-io
-    org: devstream-io # either owner or org must exist
-    name: service-A   # defaults to "app.name"
-    url: github.com/devstream-io/repo-name   # optional. if exists, no need for the scm/owner/org/name sections
-    apiURL: gitlab.com/some/path/to/your/api # optional, in case of self-managed git
-  repoTemplate:   # optional. if repoTemplate isn't empty, create repo according to the template
-    scmType: github
-    owner: devstream-io
-    org: devstream-io # either owner or org must exist
-    name: dtm-scaffolding-golang
-    url: github.com/devstream-io/repo-name   # optional. if exists, no need for the scm/owner/org/name sections
-  ci:
-  - type: template              # type template means it's a reference to the pipeline template. read the next section.
-    templateName: ci-pipeline-1
-    options: # optional, used to override defaults in the template
-    vars:    # optional, key/values to be passed to the template
-      key: value
-  cd:
-  - type: template              # type template means it's a reference to the pipeline template. read the next section.
-    templateName: cd-pipeline-1
-    options: # optional, used to override defaults in the template
-    vars:    # optional, key/values to be passed to the template
-      key: value
-```
-
-Since many key/values have default values, it's possible to use the following minimum config for the apps section:
-
-```yaml
-apps:
-- name: service-B # minimum config demo
-  spec:
-    language: python
-    framework: django
-  repo:
-    url: github.com/devstream-io/repo-name
-  repoTemplate:
-    url: github.com/devstream-io/repo-name
-  ci:
-    - type: githubactions
-  cd:
-    - type: argocdapp
-```
-
----
-
-## 6 Template File
-
-You can define some pipeline templates in the template file, like the following:
-
-```yaml
-pipelineTemplates:
-- name: ci-pipeline-1
-  type: githubactions # corresponds to a DevStream plugin
-  options:
-    branch: main      # optional
-    docker:
-      registry:
-        type: dockerhub
-        username: [[ dockerUser ]]
-        repository: [[ app ]]
-- name: cd-pipeline-1
-  type: argocdapp
-  options:
-    app:
-      namespace: argocd
-    destination:
-      server: https://kubernetes.default.svc
-      namespace: default
-    source:
-      valuefile: values.yaml
-      path: helm/[[ app ]]
-      repoURL: ${{repo-scaffolding.myapp.outputs.repoURL}}
-```
-
-Then, you can refer to these pipeline templates in the apps file.
-
----
-
-## 7 Putting It All Together
-
-Here's a complete example.
-
-Main config file:
-
-```yaml
-toolFile: "./tools.yaml"
-appFile: "./apps.yaml"
-templateFile: "./templates.yaml"
-state:
-  backend: local
-  options:
-    stateFile: devstream.state
-```
-
-Tool file:
-
-```yaml
-tools:
-- name: argocd
-  instanceID: default
-```
-
-App file:
-
-```yaml
-apps:
-- name: service-B
-  spec:
-    language: python
-    framework: django
-  repo:
-    url: github.com/devstream-io/repo-name
-  repoTemplate:
-    url: github.com/devstream-io/dtm-scaffolding-python
-  ci:
-    - type: githubactions
-  cd:
-    - type: argocdapp
-```
-
-In this example, we didn't use a var file, or template file, since they are optional and we don't need them in this example.
-
-## 8 Min Config
-
-Alternatively, you can merge multiple files into one to achieve a minimum config:
-
-```yaml
----
-state:
-  backend: local
-  options:
-    stateFile: devstream.state
----
-tools:
-- name: argocd
-  instanceID: default
----
-serviceName: test-service
-apps:
-- name: [[ serviceName ]]
-  spec:
-    language: python
-    framework: django
-  repo:
-    url: github.com/devstream-io/[[ serviceName ]]
-  repoTemplate:
-    url: github.com/devstream-io/dtm-scaffolding-python
-  ci:
-    - type: githubactions
-  cd:
-    - type: argocdapp
-```
+Similarly, if `toolFile` isn't specified in the main config, `dtm` will throw an error, even if there is a `tools.yaml` file under the current directory.

--- a/docs/core-concepts/config.zh.md
+++ b/docs/core-concepts/config.zh.md
@@ -21,11 +21,7 @@ DevStream使用YAML文件来描述你的DevOps工具链配置。
 
 ```yaml
 varFile: variables.yaml
-
 toolFile: tools.yaml
-
-pluginDir: /usr/local/devstream/plugins # 可选
-
 state:
   backend: local
   options:

--- a/docs/plugins/ci-generic.md
+++ b/docs/plugins/ci-generic.md
@@ -40,18 +40,18 @@ For more information on the main config, the tool file and the var file of DevSt
 
 ```yaml
 tools:
-  - name: ci-generic
-    instanceID: test-github
-    options:
-      ci:
-        localPath: workflows
-        type: github
-      projectRepo:
-        owner: devstream
-        org: ""
-        repo: test-repo
-        branch: main
-        repoType: github
+- name: ci-generic
+  instanceID: test-github
+  options:
+    ci:
+      localPath: workflows
+      type: github
+    projectRepo:
+      owner: devstream
+      org: ""
+      repo: test-repo
+      branch: main
+      repoType: github
 ```
 
 This config will put local workflows directory to GitHub repo's .github/workflows directory.
@@ -60,19 +60,19 @@ This config will put local workflows directory to GitHub repo's .github/workflow
 
 ```yaml
 tools:
-  - name: ci-generic
-    instanceID: test-gitlab
-    options:
-      ci:
-        remoteURL : https://raw.githubusercontent.com/DeekshithSN/Jenkinsfile/inputTest/Jenkinsfile
-        type: jenkins
-      projectRepo:
-        owner: root
-        org: ""
-        repo: test-repo
-        branch: main
-        repoType: gitlab
-        baseURL: http://127.0.0.1:30000
+- name: ci-generic
+  instanceID: test-gitlab
+  options:
+    ci:
+      remoteURL : https://raw.githubusercontent.com/DeekshithSN/Jenkinsfile/inputTest/Jenkinsfile
+      type: jenkins
+    projectRepo:
+      owner: root
+      org: ""
+      repo: test-repo
+      branch: main
+      repoType: gitlab
+      baseURL: http://127.0.0.1:30000
 ```
 
 This config will put file from [remote](https://raw.githubusercontent.com/DeekshithSN/Jenkinsfile/inputTest/Jenkinsfile)  to GitLab repo.

--- a/docs/plugins/ci-generic.zh.md
+++ b/docs/plugins/ci-generic.zh.md
@@ -38,18 +38,18 @@
 
 ```yaml
 tools:
-  - name: ci-generic
-    instanceID: test-github
-    options:
-      ci:
-        configLocation: workflows
-        type: github
-      projectRepo:
-        owner: devstream
-        org: ""
-        repo: test-repo
-        branch: main
-        repoType: github
+- name: ci-generic
+  instanceID: test-github
+  options:
+    ci:
+      configLocation: workflows
+      type: github
+    projectRepo:
+      owner: devstream
+      org: ""
+      repo: test-repo
+      branch: main
+      repoType: github
 ```
 
 这个配置将会把本地当前运行环境下的 workflows 目录放置于 GitHub 的 `.github/workflows` 目录。
@@ -58,55 +58,53 @@ tools:
 
 ```yaml
 tools:
-  - name: ci-generic
-    instanceID: test-gitlab
-    options:
-      ci:
-        configLocation : https://raw.githubusercontent.com/DeekshithSN/Jenkinsfile/inputTest/Jenkinsfile
-        type: jenkins
-      projectRepo:
-        owner: root
-        org: ""
-        repo: test-repo
-        branch: main
-        repoType: gitlab
-        baseURL: http://127.0.0.1:30000
+- name: ci-generic
+  instanceID: test-gitlab
+  options:
+    ci:
+      configLocation : https://raw.githubusercontent.com/DeekshithSN/Jenkinsfile/inputTest/Jenkinsfile
+      type: jenkins
+    projectRepo:
+      owner: root
+      org: ""
+      repo: test-repo
+      branch: main
+      repoType: gitlab
+      baseURL: http://127.0.0.1:30000
 ```
 
 这个配置将会把[URL](https://raw.githubusercontent.com/DeekshithSN/Jenkinsfile/inputTest/Jenkinsfile) 中的 Jenkinsfile 文件置于 GitLab 的仓库。
 
-
-
 #### 使用Github仓库中的CI文件
 ```yaml
 tools:
-  - name: ci-generic
-    instanceID: test-gitlab
-    options:
-      ci:
-        configLocation : git@github.com:devstream-io/devstream.git//staging/dtm-jenkins-pipeline-example/general
-        type: jenkins
-      projectRepo:
-        owner: root
-        org: ""
-        repo: test-repo
-        branch: main
-        repoType: gitlab
-        baseURL: http://127.0.0.1:30000
+- name: ci-generic
+  instanceID: test-gitlab
+  options:
+    ci:
+      configLocation : git@github.com:devstream-io/devstream.git//staging/dtm-jenkins-pipeline-example/general
+      type: jenkins
+    projectRepo:
+      owner: root
+      org: ""
+      repo: test-repo
+      branch: main
+      repoType: gitlab
+      baseURL: http://127.0.0.1:30000
 ```
 
 这个配置将会搜索[devstream 仓库](https://github.com/devstream-io/devstream)下的staging/dtm-jenkins-pipeline-example/general 目录，获取到目录下的 Jenkinsfile，置于 gitlab 仓库内。
 
-
 #### 在Devstream中直接配置CI文件
+
 ```yaml
 tools:
-  - name: ci-generic
-    instanceID: test-gitlab
-    options:
-      ci:
-        configContents:
-          pr.yaml: |
+- name: ci-generic
+  instanceID: test-gitlab
+  options:
+    ci:
+      configContents:
+        pr.yaml: |
 name: GitHub Actions Demo
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
 on: [push]

--- a/docs/plugins/helm-installer/helm-installer.zh.md
+++ b/docs/plugins/helm-installer/helm-installer.zh.md
@@ -10,7 +10,6 @@
 ---
 varFile: ""
 toolFile: ""
-pluginDir: ""
 state:
   backend: local
   options:

--- a/docs/plugins/repo-scaffolding.md
+++ b/docs/plugins/repo-scaffolding.md
@@ -102,21 +102,21 @@ These repos are official scaffolding repo to use for `sourceRepo` config, You ca
 
 ```yaml
 tools:
-  - name: repo-scaffolding
-    instanceID: golang-scaffolding
-    options:
-      destinationRepo:
-        owner: test_owner
-        org: ""
-        repo: dtm-test-golang
-        branch: main
-        repoType: github
-      sourceRepo:
-        org: devstream-io
-        repo: dtm-scaffolding-golang
-        repoType: github
-      vars:
-        ImageRepo: dtm-test/golang-repo
+- name: repo-scaffolding
+  instanceID: golang-scaffolding
+  options:
+    destinationRepo:
+      owner: test_owner
+      org: ""
+      repo: dtm-test-golang
+      branch: main
+      repoType: github
+    sourceRepo:
+      org: devstream-io
+      repo: dtm-scaffolding-golang
+      repoType: github
+    vars:
+      ImageRepo: dtm-test/golang-repo
 ```
 
 This config will create `dtm-test-golang` repo for user test_owner in GitHub, and the variable ImageRepo will be used for template render. 
@@ -125,19 +125,19 @@ This config will create `dtm-test-golang` repo for user test_owner in GitHub, an
 
 ```yaml
 tools:
-  - name: repo-scaffolding
-    instanceID: golang-cli-scaffolding
-    options:
-      destinationRepo:
-        owner: test_owner
-        org: ""
-        repo: dtm-test-golang-cli
-        branch: main
-        repoType: github
-      sourceRepo:
-        org: devstream-io
-        repo: dtm-scaffolding-golang-cli
-        repoType: github
+- name: repo-scaffolding
+  instanceID: golang-cli-scaffolding
+  options:
+    destinationRepo:
+      owner: test_owner
+      org: ""
+      repo: dtm-test-golang-cli
+      branch: main
+      repoType: github
+    sourceRepo:
+      org: devstream-io
+      repo: dtm-scaffolding-golang-cli
+      repoType: github
 ```
 
 This config will create `dtm-test-golang-cli` repo for user test_owner in GitHub.
@@ -146,21 +146,21 @@ This config will create `dtm-test-golang-cli` repo for user test_owner in GitHub
 
 ```yaml
 tools:
-  - name: repo-scaffolding
-    instanceID: java-scaffolding
-    options:
-      destinationRepo:
-        owner: test_owner
-        org: ""
-        repo: dtm-test-java
-        branch: main
-        baseUrl: 127.0.0.1:30001
-        visibility: public
-        repoType: gitlab
-      sourceRepo:
-        org: spring-guides
-        repo: gs-spring-boot
-        repoType: github
+- name: repo-scaffolding
+  instanceID: java-scaffolding
+  options:
+    destinationRepo:
+      owner: test_owner
+      org: ""
+      repo: dtm-test-java
+      branch: main
+      baseUrl: 127.0.0.1:30001
+      visibility: public
+      repoType: gitlab
+    sourceRepo:
+      org: spring-guides
+      repo: gs-spring-boot
+      repoType: github
 ```
 
 this config will create `dtm-test-java` repo for user test_owner in GitHub.

--- a/docs/plugins/zentao.md
+++ b/docs/plugins/zentao.md
@@ -18,9 +18,8 @@ For more information on the main config, the tool file and the var file of DevSt
 ```yaml
 ---
 # core config
-varFile: ''
-toolFile: ''
-pluginDir: ''
+varFile: ""
+toolFile: ""
 state: # state config, backend can be local or s3
   backend: local
   options:

--- a/docs/plugins/zentao.zh.md
+++ b/docs/plugins/zentao.zh.md
@@ -17,9 +17,8 @@
 ```yaml
 ---
 # core config
-varFile: ''
-toolFile: ''
-pluginDir: ''
+varFile: ""
+toolFile: ""
 state: # state config, backend can be local or s3
   backend: local
   options:

--- a/examples/gitops.yaml
+++ b/examples/gitops.yaml
@@ -22,83 +22,83 @@ argocdDeployTimeout: 10m
 ---
 # plugins config
 tools:
-  - name: repo-scaffolding
-    instanceID: golang-github
-    options:
-      destinationRepo:
-        owner: [[ githubUsername ]]
-        org: ""
-        repo: [[ repoName ]]
-        branch: [[ defaultBranch ]]
-        repoType: github
-      sourceRepo:
-        org: devstream-io
-        repo: dtm-scaffolding-golang
-        repoType: github
-      vars:
-        ImageRepo: "[[ dockerhubUsername ]]/[[ repoName ]]"
-  - name: jira-github-integ
-    instanceID: default
-    dependsOn: [ "repo-scaffolding.golang-github" ]
-    options:
+- name: repo-scaffolding
+  instanceID: golang-github
+  options:
+    destinationRepo:
       owner: [[ githubUsername ]]
-      repo: [[ repoName ]]
-      jiraBaseUrl: https://[[ jiraID ]].atlassian.net
-      jiraUserEmail: [[ jiraUserEmail ]]
-      jiraProjectKey: [[ jiraProjectKey ]]
-      branch: main
-  - name: githubactions-golang
-    instanceID: default
-    dependsOn: [ "repo-scaffolding.golang-github" ]
-    options:
-      owner: ${{repo-scaffolding.golang-github.outputs.owner}}
       org: ""
-      repo: ${{repo-scaffolding.golang-github.outputs.repo}}
-      language:
-        name: go
-        version: "1.18"
+      repo: [[ repoName ]]
       branch: [[ defaultBranch ]]
-      build:
+      repoType: github
+    sourceRepo:
+      org: devstream-io
+      repo: dtm-scaffolding-golang
+      repoType: github
+    vars:
+      ImageRepo: "[[ dockerhubUsername ]]/[[ repoName ]]"
+- name: jira-github-integ
+  instanceID: default
+  dependsOn: [ "repo-scaffolding.golang-github" ]
+  options:
+    owner: [[ githubUsername ]]
+    repo: [[ repoName ]]
+    jiraBaseUrl: https://[[ jiraID ]].atlassian.net
+    jiraUserEmail: [[ jiraUserEmail ]]
+    jiraProjectKey: [[ jiraProjectKey ]]
+    branch: main
+- name: githubactions-golang
+  instanceID: default
+  dependsOn: [ "repo-scaffolding.golang-github" ]
+  options:
+    owner: ${{repo-scaffolding.golang-github.outputs.owner}}
+    org: ""
+    repo: ${{repo-scaffolding.golang-github.outputs.repo}}
+    language:
+      name: go
+      version: "1.18"
+    branch: [[ defaultBranch ]]
+    build:
+      enable: True
+      command: "go build ./..."
+    test:
+      enable: True
+      command: "go test ./..."
+      coverage:
         enable: True
-        command: "go build ./..."
-      test:
-        enable: True
-        command: "go test ./..."
-        coverage:
-          enable: True
-          profile: "-race -covermode=atomic"
-          output: "coverage.out"
-      docker:
-        enable: True
-        registry:
-          type: dockerhub
-          username: [[ dockerhubUsername ]]
-          repository: ${{repo-scaffolding.golang-github.outputs.repo}}
-  - name: argocd
-    instanceID: default
-    options:
-      repo:
-        name: argo
-        url: https://argoproj.github.io/argo-helm
-      chart:
-        chartPath: ""
-        chartName: argo/argo-cd
-        releaseName: argocd
-        namespace: [[ argocdNameSpace ]]
-        wait: true
-        timeout: [[ argocdDeployTimeout ]]
-        upgradeCRDs: true
-  - name: argocdapp
-    instanceID: default
-    dependsOn: ["argocd.default", "repo-scaffolding.golang-github"]
-    options:
-      app:
-        name: ${{repo-scaffolding.golang-github.outputs.repo}}
-        namespace: [[ argocdNameSpace ]]
-      destination:
-        server: https://kubernetes.default.svc
-        namespace: default
-      source:
-        valuefile: values.yaml
-        path: helm/${{repo-scaffolding.golang-github.outputs.repo}}
-        repoURL: ${{repo-scaffolding.golang-github.outputs.repoURL}}
+        profile: "-race -covermode=atomic"
+        output: "coverage.out"
+    docker:
+      enable: True
+      registry:
+        type: dockerhub
+        username: [[ dockerhubUsername ]]
+        repository: ${{repo-scaffolding.golang-github.outputs.repo}}
+- name: argocd
+  instanceID: default
+  options:
+    repo:
+      name: argo
+      url: https://argoproj.github.io/argo-helm
+    chart:
+      chartPath: ""
+      chartName: argo/argo-cd
+      releaseName: argocd
+      namespace: [[ argocdNameSpace ]]
+      wait: true
+      timeout: [[ argocdDeployTimeout ]]
+      upgradeCRDs: true
+- name: argocdapp
+  instanceID: default
+  dependsOn: ["argocd.default", "repo-scaffolding.golang-github"]
+  options:
+    app:
+      name: ${{repo-scaffolding.golang-github.outputs.repo}}
+      namespace: [[ argocdNameSpace ]]
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: default
+    source:
+      valuefile: values.yaml
+      path: helm/${{repo-scaffolding.golang-github.outputs.repo}}
+      repoURL: ${{repo-scaffolding.golang-github.outputs.repoURL}}

--- a/examples/gitops.yaml
+++ b/examples/gitops.yaml
@@ -2,7 +2,6 @@
 # core config
 varFile: "" # If not empty, use the specified external variables config file
 toolFile: "" # If not empty, use the specified external tools config file
-pluginDir: "" # If empty, use the default value: ~/.devstream/plugins, or use -d flag to specify a directory
 state: # state config, backend can be local, s3 or k8s
   backend: local
   options:

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -2,7 +2,6 @@
 # core config
 varFile: "" # If not empty, use the specified external variables config file
 toolFile: "" # If not empty, use the specified external tools config file
-pluginDir: "" # If empty, use the default value: ~/.devstream/plugins, or use -d flag to specify a directory
 state: # state config, backend can be local, s3 or k8s
   backend: local
   options:

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -10,36 +10,36 @@ state: # state config, backend can be local, s3 or k8s
 ---
 # plugins config
 tools:
-  - name: repo-scaffolding
-    instanceID: golang-github
-    options:
-      destinationRepo:
-        owner: YOUR_GITHUB_USERNAME_CASE_SENSITIVE
-        org: ""
-        repo: go-webapp-devstream-demo
-        branch: main
-        repoType: github
-      sourceRepo:
-        org: devstream-io
-        repo: dtm-scaffolding-golang
-        repoType: github
-      vars:
-        ImageRepo: YOUR_DOCKER_USERNAME/go-webapp-devstream-demo
-  - name: githubactions-golang
-    instanceID: default
-    dependsOn: ["repo-scaffolding.golang-github"]
-    options:
+- name: repo-scaffolding
+  instanceID: golang-github
+  options:
+    destinationRepo:
       owner: YOUR_GITHUB_USERNAME_CASE_SENSITIVE
+      org: ""
       repo: go-webapp-devstream-demo
-      language:
-        name: go
-        version: "1.18"
       branch: main
-      build:
+      repoType: github
+    sourceRepo:
+      org: devstream-io
+      repo: dtm-scaffolding-golang
+      repoType: github
+    vars:
+      ImageRepo: YOUR_DOCKER_USERNAME/go-webapp-devstream-demo
+- name: githubactions-golang
+  instanceID: default
+  dependsOn: ["repo-scaffolding.golang-github"]
+  options:
+    owner: YOUR_GITHUB_USERNAME_CASE_SENSITIVE
+    repo: go-webapp-devstream-demo
+    language:
+      name: go
+      version: "1.18"
+    branch: main
+    build:
+      enable: True
+    test:
+      enable: True
+      coverage:
         enable: True
-      test:
-        enable: True
-        coverage:
-          enable: True
-      docker:
-        enable: False
+    docker:
+      enable: False

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-getter v1.6.2
 	github.com/imdario/mergo v0.3.12
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mittwald/go-helm-client v0.8.4
 	github.com/onsi/ginkgo/v2 v2.1.4
@@ -161,6 +160,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/copystructure v1.1.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect

--- a/internal/pkg/configmanager/config.go
+++ b/internal/pkg/configmanager/config.go
@@ -7,11 +7,8 @@ import (
 // Config records rendered config values and is used as a general config in DevStream.
 // Also see the rawConfig struct in rawconfig.go, it represents the original config.
 type Config struct {
-	// Command line flag have a higher priority than the config file.
-	// If you used the `--plugin-dir` flag with `dtm`, then the "pluginDir" in the config file will be ignored.
-	PluginDir string `yaml:"pluginDir"`
-	Tools     Tools  `yaml:"tools"`
-	State     *State `yaml:"state"`
+	Tools Tools  `yaml:"tools"`
+	State *State `yaml:"state"`
 }
 
 func (c *Config) validate() error {

--- a/internal/pkg/configmanager/config_test.go
+++ b/internal/pkg/configmanager/config_test.go
@@ -149,10 +149,10 @@ var _ = Describe("rawConfig struct", func() {
 				r.ToolFile = ""
 				r.totalConfigBytes = []byte(`
 tools:
-  - name: plugin1
-    instanceID: default
-    options:
-      key1: [[ var1 ]]`)
+- name: plugin1
+  instanceID: default
+  options:
+    key1: [[ var1 ]]`)
 			})
 			It("should return err", func() {
 				_, err := r.getToolsOutOfApps()
@@ -164,10 +164,10 @@ tools:
 				r.ToolFile = ""
 				r.totalConfigBytes = []byte(`
 tools:
-  - name: plugin1
-    instanceID: default
-    options:
-      key1: {{}}`)
+- name: plugin1
+  instanceID: default
+  options:
+    key1: {{}}`)
 			})
 			It("should return err", func() {
 				_, err := r.getToolsOutOfApps()

--- a/internal/pkg/configmanager/configmanager.go
+++ b/internal/pkg/configmanager/configmanager.go
@@ -36,9 +36,8 @@ func (m *Manager) LoadConfig() (*Config, error) {
 	}
 
 	config := &Config{
-		PluginDir: rawConf.PluginDir,
-		State:     rawConf.State,
-		Tools:     tools,
+		State: rawConf.State,
+		Tools: tools,
 	}
 	if err = config.validate(); err != nil {
 		return nil, err

--- a/internal/pkg/configmanager/configmanager_test.go
+++ b/internal/pkg/configmanager/configmanager_test.go
@@ -93,7 +93,6 @@ const (
 	toolFile       = "tool.yaml"
 	appFile        = "app.yaml"
 	templateFile   = "template.yaml"
-	pluginDir      = "./plugins"
 )
 
 var _ = Describe("LoadConfig", func() {
@@ -107,8 +106,7 @@ var _ = Describe("LoadConfig", func() {
 	}
 
 	var expectedConfig = &configmanager.Config{
-		PluginDir: pluginDir,
-		State:     state,
+		State: state,
 	}
 
 	BeforeEach(func() {
@@ -133,7 +131,6 @@ varFile: %s
 toolFile: %s
 appFile: %s
 templateFile: %s
-pluginDir: %s
 state: # state config, backend can be local or s3
   backend: local
   options:
@@ -141,7 +138,7 @@ state: # state config, backend can be local or s3
 
 var1: value-of-var1 # var1 is a global var
 
-`, varFile, toolFile, appFile, templateFile, pluginDir)
+`, varFile, toolFile, appFile, templateFile)
 			err := os.WriteFile(filepath.Join(tmpDir, mainConfigFile), []byte(mainConfig), 0644)
 			Expect(err).Should(Succeed())
 		})
@@ -262,7 +259,6 @@ var1: value-of-var1 # var1 is a global var
 			config, err := manager.LoadConfig()
 			Expect(err).Should(Succeed())
 			Expect(config).ShouldNot(BeNil())
-			Expect(config.PluginDir).Should(Equal(expectedConfig.PluginDir))
 			Expect(config.State).Should(Equal(expectedConfig.State))
 			Expect(len(config.Tools)).Should(Equal(5))
 			Expect(config.Tools[0]).Should(Equal(expectedTools1))
@@ -277,7 +273,6 @@ var1: value-of-var1 # var1 is a global var
 		BeforeEach(func() {
 			mainConfig = fmt.Sprintf(`# main config
 toolFile: %s
-pluginDir: %s
 var1: test
 var2: test2
 state: # state config, backend can be local or s3
@@ -294,7 +289,7 @@ tools:
     options:
       key1: value1
       key2: [[ var2 ]]
-`, toolFile, pluginDir)
+`, toolFile)
 			err := os.WriteFile(filepath.Join(tmpDir, mainConfigFile), []byte(mainConfig), 0644)
 			Expect(err).Should(Succeed())
 		})
@@ -303,7 +298,6 @@ tools:
 			config, err := manager.LoadConfig()
 			Expect(err).Should(Succeed())
 			Expect(config).ShouldNot(BeNil())
-			Expect(config.PluginDir).Should(Equal(expectedConfig.PluginDir))
 			Expect(config.State).Should(Equal(expectedConfig.State))
 			Expect(len(config.Tools)).Should(Equal(4))
 		})
@@ -315,7 +309,6 @@ tools:
 ---
 varFile:
 toolFile:
-pluginDir: ""
 state:
   backend: local
   options:
@@ -396,7 +389,6 @@ tools:
 			config, err := manager.LoadConfig()
 			Expect(err).Should(Succeed())
 			Expect(config).ShouldNot(BeNil())
-			Expect(config.PluginDir).Should(Equal(""))
 			Expect(len(config.Tools)).Should(Equal(3))
 		})
 	})

--- a/internal/pkg/configmanager/configmanager_test.go
+++ b/internal/pkg/configmanager/configmanager_test.go
@@ -12,79 +12,79 @@ import (
 )
 
 const appConfig = `apps:
-  - name: service-A
-    spec:
-      language: python
-      framework: django
-    repo:
-      scmType: github
-      owner: devstream-io
-      org: devstream-io # choose between owner and org
-      url: github.com/devstream-io/service-A # optional，if url is specified，we can infer scm/owner/org/name from url
-      apiURL: gitlab.com/some/path/to/your/api # optional, if you want to create a repo from repo template
-    # if repoTemplate is not empty，we could help user to create repo from scaffoldingRepo
-    repoTemplate: # optional
-      scmType: github
-      owner: devstream-io
-      org: devstream-io # choose between owner and org
-      name: dtm-scaffolding-golang
-      url: github.com/devstream-io/dtm-scaffolding-golang # optional，if url is specified，we can infer scm/owner/org/name from url
-    ci:
-      - type: template
-        templateName: ci-pipeline-1
-        options: # overwrite options in pipelineTemplates
-          docker:
-            registry:
-              type: [[ var3 ]] # while overridden, use global variables
-        vars: # optional, use to render vars in template（valid only if the ci.type is template）
-          dockerUser: dockerUser1
-          app: service-A
-    cd:
-      - type: template
-        templateName: cd-pipeline-1
-        options: # overwrite options in pipelineTemplates
-          destination:
-            namespace: devstream-io
-        vars: # optional, use to render vars in template（valid only if the cd.type is template）
-          app: service-A
+- name: service-A
+  spec:
+    language: python
+    framework: django
+  repo:
+    scmType: github
+    owner: devstream-io
+    org: devstream-io # choose between owner and org
+    url: github.com/devstream-io/service-A # optional，if url is specified，we can infer scm/owner/org/name from url
+    apiURL: gitlab.com/some/path/to/your/api # optional, if you want to create a repo from repo template
+  # if repoTemplate is not empty，we could help user to create repo from scaffoldingRepo
+  repoTemplate: # optional
+    scmType: github
+    owner: devstream-io
+    org: devstream-io # choose between owner and org
+    name: dtm-scaffolding-golang
+    url: github.com/devstream-io/dtm-scaffolding-golang # optional，if url is specified，we can infer scm/owner/org/name from url
+  ci:
+  - type: template
+    templateName: ci-pipeline-1
+    options: # overwrite options in pipelineTemplates
+      docker:
+        registry:
+          type: [[ var3 ]] # while overridden, use global variables
+    vars: # optional, use to render vars in template（valid only if the ci.type is template）
+      dockerUser: dockerUser1
+      app: service-A
+  cd:
+  - type: template
+    templateName: cd-pipeline-1
+    options: # overwrite options in pipelineTemplates
+      destination:
+        namespace: devstream-io
+    vars: # optional, use to render vars in template（valid only if the cd.type is template）
+      app: service-A
 `
 const toolConfig = `tools:
-  - name: plugin1
-    instanceID: default
-    options:
-      key1: [[ var1 ]]
-  - name: plugin2
-    instanceID: ins2
-    options:
-      key1: value1
-      key2: [[ var2 ]]
+- name: plugin1
+  instanceID: default
+  options:
+    key1: [[ var1 ]]
+- name: plugin2
+  instanceID: ins2
+  options:
+    key1: value1
+    key2: [[ var2 ]]
 `
 const varConfig = `var2: value-of-var2
 var3: dockerhub-overwrite
 argocdNamespace: argocd
 `
 const templateConfig = `pipelineTemplates:
-  - name: ci-pipeline-1
-    type: github-actions # corresponding to a plugin
-    options:
-      branch: main # optional, default is main
-      docker:
-        registry:
-          type: dockerhub
-          username: [[ dockerUser ]]
-          repository: [[ app ]]
-  - name: cd-pipeline-1
-    type: argocdapp
-    options:
-      app:
-        namespace: [[ argocdNamespace ]] # you can use global vars in templates
-      destination:
-        server: https://kubernetes.default.svc
-        namespace: default
-      source:
-        valuefile: values.yaml
-        path: helm/[[ app ]]
-        repoURL: ${{repo-scaffolding.myapp.outputs.repoURL}}
+- name: ci-pipeline-1
+  type: github-actions # corresponding to a plugin
+  options:
+    branch: main # optional, default is main
+    docker:
+      registry:
+        type: dockerhub
+        username: [[ dockerUser ]]
+        repository: [[ app ]]
+- name: cd-pipeline-1
+  type: argocdapp
+  options:
+    app:
+      namespace: [[ argocdNamespace ]] # you can use global vars in templates
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: default
+    source:
+      valuefile: values.yaml
+      path: helm/[[ app ]]
+      repoURL: ${{repo-scaffolding.myapp.outputs.repoURL}}
 `
 
 const (
@@ -280,15 +280,15 @@ state: # state config, backend can be local or s3
   options:
     stateFile: devstream.state
 tools:
-  - name: plugin1
-    instanceID: default
-    options:
-      config: app
-  - name: plugin3
-    instanceID: ins2
-    options:
-      key1: value1
-      key2: [[ var2 ]]
+- name: plugin1
+  instanceID: default
+  options:
+    config: app
+- name: plugin3
+  instanceID: ins2
+  options:
+    key1: value1
+    key2: [[ var2 ]]
 `, toolFile)
 			err := os.WriteFile(filepath.Join(tmpDir, mainConfigFile), []byte(mainConfig), 0644)
 			Expect(err).Should(Succeed())
@@ -329,58 +329,58 @@ argocdDeployTimeout: 10m
 ---
 # plugins config
 tools:
-  - name: repo-scaffolding
-    instanceID: golang-github
-    options:
-      destinationRepo:
-        owner: [[ githubUsername ]]
-        org: ""
-        repo: [[ repoName ]]
-        branch: [[ defaultBranch ]]
-        repoType: github
-      sourceRepo:
-        org: devstream-io
-        repo: dtm-scaffolding-golang
-        repoType: github
-      vars:
-        ImageRepo: "[[ dockerhubUsername ]]/[[ repoName ]]"
-  - name: jira-github-integ
-    instanceID: default
-    dependsOn: [ "repo-scaffolding.golang-github" ]
-    options:
+- name: repo-scaffolding
+  instanceID: golang-github
+  options:
+    destinationRepo:
       owner: [[ githubUsername ]]
-      repo: [[ repoName ]]
-      jiraBaseUrl: https://[[ jiraID ]].atlassian.net
-      jiraUserEmail: [[ jiraUserEmail ]]
-      jiraProjectKey: [[ jiraProjectKey ]]
-      branch: main
-  - name: githubactions-golang
-    instanceID: default
-    dependsOn: [ "repo-scaffolding.golang-github" ]
-    options:
-      owner: ${{repo-scaffolding.golang-github.outputs.owner}}
       org: ""
-      repo: ${{repo-scaffolding.golang-github.outputs.repo}}
-      language:
-        name: go
-        version: "1.18"
+      repo: [[ repoName ]]
       branch: [[ defaultBranch ]]
-      build:
+      repoType: github
+    sourceRepo:
+      org: devstream-io
+      repo: dtm-scaffolding-golang
+      repoType: github
+    vars:
+      ImageRepo: "[[ dockerhubUsername ]]/[[ repoName ]]"
+- name: jira-github-integ
+  instanceID: default
+  dependsOn: [ "repo-scaffolding.golang-github" ]
+  options:
+    owner: [[ githubUsername ]]
+    repo: [[ repoName ]]
+    jiraBaseUrl: https://[[ jiraID ]].atlassian.net
+    jiraUserEmail: [[ jiraUserEmail ]]
+    jiraProjectKey: [[ jiraProjectKey ]]
+    branch: main
+- name: githubactions-golang
+  instanceID: default
+  dependsOn: [ "repo-scaffolding.golang-github" ]
+  options:
+    owner: ${{repo-scaffolding.golang-github.outputs.owner}}
+    org: ""
+    repo: ${{repo-scaffolding.golang-github.outputs.repo}}
+    language:
+      name: go
+      version: "1.18"
+    branch: [[ defaultBranch ]]
+    build:
+      enable: True
+      command: "go build ./..."
+    test:
+      enable: True
+      command: "go test ./..."
+      coverage:
         enable: True
-        command: "go build ./..."
-      test:
-        enable: True
-        command: "go test ./..."
-        coverage:
-          enable: True
-          profile: "-race -covermode=atomic"
-          output: "coverage.out"
-      docker:
-        enable: True
-        registry:
-          type: dockerhub
-          username: [[ dockerhubUsername ]]
-          repository: ${{repo-scaffolding.golang-github.outputs.repo}}`
+        profile: "-race -covermode=atomic"
+        output: "coverage.out"
+    docker:
+      enable: True
+      registry:
+        type: dockerhub
+        username: [[ dockerhubUsername ]]
+        repository: ${{repo-scaffolding.golang-github.outputs.repo}}`
 			err := os.WriteFile(filepath.Join(tmpDir, mainConfigFile), []byte(mainConfig), 0644)
 			Expect(err).Should(Succeed())
 		})
@@ -408,10 +408,10 @@ var _ = Describe("Manager struct", func() {
 		fLoc = f.Name()
 		err = os.WriteFile(fLoc, []byte(`
 tools:
-  - name: plugin1
-    instanceID: default
-    options:
-      key1: test
+- name: plugin1
+  instanceID: default
+  options:
+    key1: test
 		`), 0666)
 		Expect(err).Error().ShouldNot(HaveOccurred())
 		m.ConfigFilePath = fLoc
@@ -475,7 +475,6 @@ state:
 				_, err := m.LoadConfig()
 				Expect(err).Error().Should(HaveOccurred())
 			})
-
 		})
 	})
 })

--- a/internal/pkg/configmanager/rawconfig.go
+++ b/internal/pkg/configmanager/rawconfig.go
@@ -26,7 +26,6 @@ type rawConfig struct {
 	ToolFile          string       `yaml:"toolFile" mapstructure:"toolFile"`
 	AppFile           string       `yaml:"appFile" mapstructure:"appFile"`
 	TemplateFile      string       `yaml:"templateFile" mapstructure:"templateFile"`
-	PluginDir         string       `yaml:"pluginDir" mapstructure:"pluginDir"`
 	State             *State       `yaml:"state" mapstructure:"state"`
 	Apps              []RawOptions `yaml:"apps"`
 	Tools             []RawOptions `yaml:"tools"`

--- a/internal/pkg/configmanager/tool.go
+++ b/internal/pkg/configmanager/tool.go
@@ -36,7 +36,7 @@ func newTool(name, instanceID string, options RawOptions) *Tool {
 		options = make(RawOptions)
 	}
 	// set instanceID to options
-	options["instanceID"] = interface{}(instanceID)
+	options["instanceID"] = instanceID
 
 	return &Tool{
 		Name:       name,

--- a/internal/pkg/pluginengine/cmd_apply.go
+++ b/internal/pkg/pluginengine/cmd_apply.go
@@ -19,10 +19,6 @@ func Apply(configFile string, continueDirectly bool) error {
 		return err
 	}
 
-	if err = SetPluginDir(cfg.PluginDir); err != nil {
-		log.Errorf("Error: %s.", err)
-	}
-
 	err = pluginmanager.CheckLocalPlugins(cfg.Tools)
 	if err != nil {
 		log.Error(`Error checking required plugins. Maybe you forgot to run "dtm init" first?`)

--- a/internal/pkg/pluginengine/cmd_delete.go
+++ b/internal/pkg/pluginengine/cmd_delete.go
@@ -17,10 +17,6 @@ func Remove(configFile string, continueDirectly bool, isForceDelete bool) error 
 		return err
 	}
 
-	if err = SetPluginDir(cfg.PluginDir); err != nil {
-		log.Errorf("Error: %s.", err)
-	}
-
 	err = pluginmanager.CheckLocalPlugins(cfg.Tools)
 	if err != nil {
 		log.Errorf(`Error checking required plugins. Maybe you forgot to run "dtm init" first?`)

--- a/internal/pkg/pluginengine/cmd_destroy.go
+++ b/internal/pkg/pluginengine/cmd_destroy.go
@@ -20,10 +20,6 @@ func Destroy(configFile string, continueDirectly bool, isForceDestroy bool) erro
 		return fmt.Errorf("failed to load the config file")
 	}
 
-	if err = SetPluginDir(cfg.PluginDir); err != nil {
-		log.Errorf("Error: %s.", err)
-	}
-
 	smgr, err := statemanager.NewManager(*cfg.State)
 	if err != nil {
 		log.Debugf("Failed to get the manager: %s.", err)

--- a/internal/pkg/pluginengine/cmd_verify.go
+++ b/internal/pkg/pluginengine/cmd_verify.go
@@ -19,10 +19,6 @@ func Verify(configFile string) bool {
 		return false
 	}
 
-	if err = SetPluginDir(cfg.PluginDir); err != nil {
-		log.Errorf("Error: %s.", err)
-	}
-
 	// 2. according to the config, all needed plugins exist
 	err = pluginmanager.CheckLocalPlugins(cfg.Tools)
 	if err != nil {

--- a/internal/pkg/pluginengine/plugin.go
+++ b/internal/pkg/pluginengine/plugin.go
@@ -1,16 +1,9 @@
 package pluginengine
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
-
-	"github.com/mitchellh/go-homedir"
-	"github.com/spf13/viper"
-
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
+	"github.com/devstream-io/devstream/internal/pkg/pluginmanager"
 	"github.com/devstream-io/devstream/internal/pkg/statemanager"
-	"github.com/devstream-io/devstream/pkg/util/log"
 )
 
 // DevStreamPlugin is a struct, on which Create/Read/Update/Delete interfaces are defined.
@@ -25,7 +18,11 @@ type DevStreamPlugin interface {
 
 // Create loads the plugin and calls the Create method of that plugin.
 func Create(tool *configmanager.Tool) (statemanager.ResourceStatus, error) {
-	pluginDir := viper.GetString("plugin-dir")
+	pluginDir, err := pluginmanager.GetPluginDir()
+	if err != nil {
+		return nil, err
+	}
+
 	p, err := loadPlugin(pluginDir, tool)
 	if err != nil {
 		return nil, err
@@ -36,7 +33,11 @@ func Create(tool *configmanager.Tool) (statemanager.ResourceStatus, error) {
 
 // Update loads the plugin and calls the Update method of that plugin.
 func Update(tool *configmanager.Tool) (statemanager.ResourceStatus, error) {
-	pluginDir := viper.GetString("plugin-dir")
+	pluginDir, err := pluginmanager.GetPluginDir()
+	if err != nil {
+		return nil, err
+	}
+
 	p, err := loadPlugin(pluginDir, tool)
 	if err != nil {
 		return nil, err
@@ -46,7 +47,11 @@ func Update(tool *configmanager.Tool) (statemanager.ResourceStatus, error) {
 }
 
 func Read(tool *configmanager.Tool) (statemanager.ResourceStatus, error) {
-	pluginDir := viper.GetString("plugin-dir")
+	pluginDir, err := pluginmanager.GetPluginDir()
+	if err != nil {
+		return nil, err
+	}
+
 	p, err := loadPlugin(pluginDir, tool)
 	if err != nil {
 		return nil, err
@@ -57,7 +62,11 @@ func Read(tool *configmanager.Tool) (statemanager.ResourceStatus, error) {
 
 // Delete loads the plugin and calls the Delete method of that plugin.
 func Delete(tool *configmanager.Tool) (bool, error) {
-	pluginDir := viper.GetString("plugin-dir")
+	pluginDir, err := pluginmanager.GetPluginDir()
+	if err != nil {
+		return false, err
+	}
+
 	p, err := loadPlugin(pluginDir, tool)
 	if err != nil {
 		return false, err
@@ -67,52 +76,5 @@ func Delete(tool *configmanager.Tool) (bool, error) {
 }
 
 func renderInstanceIDtoOptions(tool *configmanager.Tool) {
-	tool.Options["instanceID"] = interface{}(tool.InstanceID)
-}
-
-func SetPluginDir(conf string) error {
-	pluginDir, err := getPluginDir(conf)
-	if err != nil {
-		return err
-	}
-	viper.Set("plugin-dir", pluginDir)
-	return nil
-}
-
-func getPluginDir(conf string) (string, error) {
-	pluginDir := viper.GetString("plugin-dir")
-	if pluginDir == "" {
-		pluginDir = conf
-	}
-
-	if pluginDir == "" {
-		homeDir, err := homedir.Dir()
-		if err != nil {
-			return "", err
-		}
-		defaultPluginDir := filepath.Join(homeDir, ".devstream", "plugins")
-		return defaultPluginDir, nil
-	}
-
-	pluginRealDir, err := handlePathWithHome(pluginDir)
-	if err != nil {
-		return "", err
-	}
-	return pluginRealDir, nil
-}
-
-// handlePathWithHome deal with "~" in the filePath
-func handlePathWithHome(filePath string) (string, error) {
-	if !strings.Contains(filePath, "~") {
-		return filePath, nil
-	}
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	retPath := filepath.Join(homeDir, strings.TrimPrefix(filePath, "~"))
-	log.Debugf("real path: %s.", retPath)
-
-	return retPath, nil
+	tool.Options["instanceID"] = tool.InstanceID
 }

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/viper"
 
@@ -94,23 +95,21 @@ func downloadPlugins(baseURL string, tools []configmanager.Tool, pluginDir, osNa
 
 // CheckLocalPlugins checks if the local plugins exists, and matches with md5 value.
 func CheckLocalPlugins(tools []configmanager.Tool) error {
-	pluginDir := viper.GetString("plugin-dir")
-	if pluginDir == "" {
-		return fmt.Errorf(`plugins directory should not be ""`)
+	pluginDir, err := GetPluginDir()
+	if err != nil {
+		return err
 	}
-
-	log.Infof("Using dir <%s> to store plugins.", pluginDir)
 
 	for _, tool := range tools {
 		pluginFileName := tool.GetPluginFileName()
 		pluginMD5FileName := tool.GetPluginMD5FileName()
-		if _, err := os.Stat(filepath.Join(pluginDir, pluginFileName)); err != nil {
+		if _, err = os.Stat(filepath.Join(pluginDir, pluginFileName)); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				return fmt.Errorf("plugin %s doesn't exist", tool.Name)
 			}
 			return err
 		}
-		if _, err := os.Stat(filepath.Join(pluginDir, pluginMD5FileName)); err != nil {
+		if _, err = os.Stat(filepath.Join(pluginDir, pluginMD5FileName)); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				return fmt.Errorf(".md5 file of plugin %s doesn't exist", tool.Name)
 			}
@@ -138,4 +137,36 @@ func ifPluginAndMD5Match(pluginDir, soFileName, md5FileName string) (bool, error
 		return false, err
 	}
 	return isMD5Match, nil
+}
+
+func GetPluginDir() (string, error) {
+	pluginDir := viper.GetString("plugin-dir")
+	if pluginDir == "" {
+		return "", fmt.Errorf(`plugins directory is ""`)
+	}
+	log.Debugf("Plugin directory: %s.", pluginDir)
+
+	realPluginDir, err := handlePathWithHome(pluginDir)
+	if err != nil {
+		return "", err
+	}
+	log.Debugf("Real plugin directory: %s.", realPluginDir)
+
+	return realPluginDir, nil
+}
+
+// handlePathWithHome deal with "~" in the filePath
+func handlePathWithHome(filePath string) (string, error) {
+	if !strings.Contains(filePath, "~") {
+		return filePath, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	retPath := filepath.Join(homeDir, strings.TrimPrefix(filePath, "~"))
+	log.Debugf("real path: %s.", retPath)
+
+	return retPath, nil
 }

--- a/internal/pkg/pluginmanager/manager.go
+++ b/internal/pkg/pluginmanager/manager.go
@@ -105,7 +105,7 @@ func CheckLocalPlugins(tools []configmanager.Tool) error {
 		pluginMD5FileName := tool.GetPluginMD5FileName()
 		if _, err = os.Stat(filepath.Join(pluginDir, pluginFileName)); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("plugin %s doesn't exist", tool.Name)
+				return fmt.Errorf("plugin %s(%s) doesn't exist", tool.Name, pluginFileName)
 			}
 			return err
 		}

--- a/internal/pkg/show/config/default.yaml
+++ b/internal/pkg/show/config/default.yaml
@@ -12,19 +12,19 @@ state:
 
 # tools.yaml sample:
 tools:
-  - name: repo-scaffolding
-    instanceID: default
-    options:
-    destinationRepo:
-      owner: [[ githubUsername ]]
-      org: ""
-      repo: [[ repo ]]
-      branch: main
-      repoType: github
-    sourceRepo:
-      org: devstream-io
-      repo: dtm-scaffolding-golang
-      repoType: github
+- name: repo-scaffolding
+  instanceID: default
+  options:
+  destinationRepo:
+    owner: [[ githubUsername ]]
+    org: ""
+    repo: [[ repo ]]
+    branch: main
+    repoType: github
+  sourceRepo:
+    org: devstream-io
+    repo: dtm-scaffolding-golang
+    repoType: github
 
 # variables.yaml sample:
 githubUsername: daniel-hutao

--- a/internal/pkg/show/config/templates/gitops.yaml
+++ b/internal/pkg/show/config/templates/gitops.yaml
@@ -22,83 +22,83 @@ argocdDeployTimeout: 10m
 ---
 # plugins config
 tools:
-  - name: repo-scaffolding
-    instanceID: golang-github
-    options:
-      destinationRepo:
-        owner: [[ githubUsername ]]
-        org: ""
-        repo: [[ repoName ]]
-        branch: [[ defaultBranch ]]
-        repoType: github
-      sourceRepo:
-        org: devstream-io
-        repo: dtm-scaffolding-golang
-        repoType: github
-      vars:
-        ImageRepo: "[[ dockerhubUsername ]]/[[ repoName ]]"
-  - name: jira-github-integ
-    instanceID: default
-    dependsOn: [ "repo-scaffolding.golang-github" ]
-    options:
+- name: repo-scaffolding
+  instanceID: golang-github
+  options:
+    destinationRepo:
       owner: [[ githubUsername ]]
-      repo: [[ repoName ]]
-      jiraBaseUrl: https://[[ jiraID ]].atlassian.net
-      jiraUserEmail: [[ jiraUserEmail ]]
-      jiraProjectKey: [[ jiraProjectKey ]]
-      branch: main
-  - name: githubactions-golang
-    instanceID: default
-    dependsOn: [ "repo-scaffolding.golang-github" ]
-    options:
-      owner: ${{repo-scaffolding.golang-github.outputs.owner}}
       org: ""
-      repo: ${{repo-scaffolding.golang-github.outputs.repo}}
-      language:
-        name: go
-        version: "1.18"
+      repo: [[ repoName ]]
       branch: [[ defaultBranch ]]
-      build:
+      repoType: github
+    sourceRepo:
+      org: devstream-io
+      repo: dtm-scaffolding-golang
+      repoType: github
+    vars:
+      ImageRepo: "[[ dockerhubUsername ]]/[[ repoName ]]"
+- name: jira-github-integ
+  instanceID: default
+  dependsOn: [ "repo-scaffolding.golang-github" ]
+  options:
+    owner: [[ githubUsername ]]
+    repo: [[ repoName ]]
+    jiraBaseUrl: https://[[ jiraID ]].atlassian.net
+    jiraUserEmail: [[ jiraUserEmail ]]
+    jiraProjectKey: [[ jiraProjectKey ]]
+    branch: main
+- name: githubactions-golang
+  instanceID: default
+  dependsOn: [ "repo-scaffolding.golang-github" ]
+  options:
+    owner: ${{repo-scaffolding.golang-github.outputs.owner}}
+    org: ""
+    repo: ${{repo-scaffolding.golang-github.outputs.repo}}
+    language:
+      name: go
+      version: "1.18"
+    branch: [[ defaultBranch ]]
+    build:
+      enable: True
+      command: "go build ./..."
+    test:
+      enable: True
+      command: "go test ./..."
+      coverage:
         enable: True
-        command: "go build ./..."
-      test:
-        enable: True
-        command: "go test ./..."
-        coverage:
-          enable: True
-          profile: "-race -covermode=atomic"
-          output: "coverage.out"
-      docker:
-        enable: True
-        registry:
-          type: dockerhub
-          username: [[ dockerhubUsername ]]
-          repository: ${{repo-scaffolding.golang-github.outputs.repo}}
-  - name: argocd
-    instanceID: default
-    options:
-      repo:
-        name: argo
-        url: https://argoproj.github.io/argo-helm
-      chart:
-        chartPath: ""
-        chartName: argo/argo-cd
-        releaseName: argocd
-        namespace: [[ argocdNameSpace ]]
-        wait: true
-        timeout: [[ argocdDeployTimeout ]]
-        upgradeCRDs: true
-  - name: argocdapp
-    instanceID: default
-    dependsOn: ["argocd.default", "repo-scaffolding.golang-github"]
-    options:
-      app:
-        name: ${{repo-scaffolding.golang-github.outputs.repo}}
-        namespace: [[ argocdNameSpace ]]
-      destination:
-        server: https://kubernetes.default.svc
-        namespace: default
-      source:
-        valuefile: values.yaml
-        path: helm/${{repo-scaffolding.golang-github.outputs.repo}}
-        repoURL: ${{repo-scaffolding.golang-github.outputs.repoURL}}
+        profile: "-race -covermode=atomic"
+        output: "coverage.out"
+    docker:
+      enable: True
+      registry:
+        type: dockerhub
+        username: [[ dockerhubUsername ]]
+        repository: ${{repo-scaffolding.golang-github.outputs.repo}}
+- name: argocd
+  instanceID: default
+  options:
+    repo:
+      name: argo
+      url: https://argoproj.github.io/argo-helm
+    chart:
+      chartPath: ""
+      chartName: argo/argo-cd
+      releaseName: argocd
+      namespace: [[ argocdNameSpace ]]
+      wait: true
+      timeout: [[ argocdDeployTimeout ]]
+      upgradeCRDs: true
+- name: argocdapp
+  instanceID: default
+  dependsOn: ["argocd.default", "repo-scaffolding.golang-github"]
+  options:
+    app:
+      name: ${{repo-scaffolding.golang-github.outputs.repo}}
+      namespace: [[ argocdNameSpace ]]
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: default
+    source:
+      valuefile: values.yaml
+      path: helm/${{repo-scaffolding.golang-github.outputs.repo}}
+      repoURL: ${{repo-scaffolding.golang-github.outputs.repoURL}}

--- a/internal/pkg/show/config/templates/gitops.yaml
+++ b/internal/pkg/show/config/templates/gitops.yaml
@@ -2,7 +2,6 @@
 # core config
 varFile: "" # If not empty, use the specified external variables config file
 toolFile: "" # If not empty, use the specified external tools config file
-pluginDir: "" # If empty, use the default value: ~/.devstream/plugins, or use -d flag to specify a directory
 state: # state config, backend can be local, s3 or k8s
   backend: local
   options:

--- a/internal/pkg/show/config/templates/quickstart.yaml
+++ b/internal/pkg/show/config/templates/quickstart.yaml
@@ -2,7 +2,6 @@
 # core config
 varFile: "" # If not empty, use the specified external variables config file
 toolFile: "" # If not empty, use the specified external tools config file
-pluginDir: "" # If empty, use the default value: ~/.devstream/plugins, or use -d flag to specify a directory
 state: # state config, backend can be local, s3 or k8s
   backend: local
   options:

--- a/internal/pkg/show/config/templates/quickstart.yaml
+++ b/internal/pkg/show/config/templates/quickstart.yaml
@@ -10,36 +10,36 @@ state: # state config, backend can be local, s3 or k8s
 ---
 # plugins config
 tools:
-  - name: repo-scaffolding
-    instanceID: golang-github
-    options:
-      destinationRepo:
-        owner: YOUR_GITHUB_USERNAME_CASE_SENSITIVE
-        org: ""
-        repo: go-webapp-devstream-demo
-        branch: main
-        repoType: github
-      sourceRepo:
-        org: devstream-io
-        repo: dtm-scaffolding-golang
-        repoType: github
-      vars:
-        ImageRepo: YOUR_DOCKER_USERNAME/go-webapp-devstream-demo
-  - name: githubactions-golang
-    instanceID: default
-    dependsOn: ["repo-scaffolding.golang-github"]
-    options:
+- name: repo-scaffolding
+  instanceID: golang-github
+  options:
+    destinationRepo:
       owner: YOUR_GITHUB_USERNAME_CASE_SENSITIVE
+      org: ""
       repo: go-webapp-devstream-demo
-      language:
-        name: go
-        version: "1.18"
       branch: main
-      build:
+      repoType: github
+    sourceRepo:
+      org: devstream-io
+      repo: dtm-scaffolding-golang
+      repoType: github
+    vars:
+      ImageRepo: YOUR_DOCKER_USERNAME/go-webapp-devstream-demo
+- name: githubactions-golang
+  instanceID: default
+  dependsOn: ["repo-scaffolding.golang-github"]
+  options:
+    owner: YOUR_GITHUB_USERNAME_CASE_SENSITIVE
+    repo: go-webapp-devstream-demo
+    language:
+      name: go
+      version: "1.18"
+    branch: main
+    build:
+      enable: True
+    test:
+      enable: True
+      coverage:
         enable: True
-      test:
-        enable: True
-        coverage:
-          enable: True
-      docker:
-        enable: False
+    docker:
+      enable: False

--- a/internal/pkg/show/status/status.go
+++ b/internal/pkg/show/status/status.go
@@ -35,10 +35,6 @@ func Show(configFile string) error {
 		return fmt.Errorf("failed to load the config file")
 	}
 
-	if err = pluginengine.SetPluginDir(cfg.PluginDir); err != nil {
-		log.Errorf("Error: %s.", err)
-	}
-
 	smgr, err := statemanager.NewManager(*cfg.State)
 	if err != nil {
 		log.Debugf("Failed to get State Manager: %s.", err)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,144 +2,144 @@ site_name: "DevStream - Your DevOps Toolchain Manager"
 theme:
   name: material
   features:
-    - content.tabs.link
-    - content.code.annotate
+  - content.tabs.link
+  - content.code.annotate
   palette:
-    - scheme: default
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
-    - scheme: slate
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/brightness-4
-        name: Switch to light mode
+  - scheme: default
+    primary: indigo
+    accent: indigo
+    toggle:
+      icon: material/brightness-7
+      name: Switch to dark mode
+  - scheme: slate
+    primary: indigo
+    accent: indigo
+    toggle:
+      icon: material/brightness-4
+      name: Switch to light mode
 edit_uri: edit/main/docs
 site_url: https://docs.devstream.io
 repo_name: devstream
 repo_url: https://github.com/devstream-io/devstream
 site_description: The DevStream Docs
 markdown_extensions:
-  - toc:
-      permalink: true
-  - pymdownx.snippets:
-      base_path:
-        - "docs"
-        - "docs/../internal/pkg/show/config/plugins/"
-  - pymdownx.highlight:
-      anchor_linenums: true
-      auto_title: true
-  - pymdownx.superfences
-  - pymdownx.tabbed:
-      alternate_style: true
-  - attr_list
-  - md_in_html
-  - admonition
-  - pymdownx.details
+- toc:
+    permalink: true
+- pymdownx.snippets:
+    base_path:
+    - "docs"
+    - "docs/../internal/pkg/show/config/plugins/"
+- pymdownx.highlight:
+    anchor_linenums: true
+    auto_title: true
+- pymdownx.superfences
+- pymdownx.tabbed:
+    alternate_style: true
+- attr_list
+- md_in_html
+- admonition
+- pymdownx.details
 extra_css:
 - assets/versions.css
 extra_javascript:
 - assets/versions.js
 extra:
   alternate:
-    - name: English
-      link: ""
-      lang: en
-    - name: 中文
-      link: index.zh/
-      lang: zh
+  - name: English
+    link: ""
+    lang: en
+  - name: 中文
+    link: index.zh/
+    lang: zh
 plugins:
-  - search:
-  - i18n:
-      languages:
-        en: "English"
-        zh: "简体中文"
-      default_language: 'en'
-      no_translation:
-        en: "This page isn't translated to English."
-        zh: "这个页面还没有中文翻译。"
-      translate_nav:
-        en:
-          DTM Commands Explained in Depth: "DTM Commands Explained in Depth"
-          Plugins: "Plugins"
-          Best Practices: "Best Practices"
-          Developer Guide: "Developer Guide"
-          Core Concepts: "Core Concepts"
-          Commands: "Commands"
-          Contributor Ladder: "Contributor Ladder"
-          Road Map: "Road Map"
-          Code Review Guide: "Code Review Guide"
-          Overview: "Overview"
-          Contribute Workflow: "Contribute Workflow"
-          DevStream Architecture: "DevStream Architecture"
-          Environment Setup and Development: "Environment Setup and Development"
-          Docs Contribution: "Docs Contribution"
-          Helm Installer: "Helm Installer"
-        zh:
-          DTM Commands Explained in Depth: "DTM 命令详解"
-          Plugins: "插件"
-          Best Practices: "最佳实践"
-          Developer Guide: "开发指导"
-          Core Concepts: "核心概念"
-          Commands: "命令"
-          Contributor Ladder: "贡献者成长阶梯"
-          Road Map: "路线图"
-          Code Review Guide: "代码 review 指导"
-          Overview: "概览"
-          Contribute Workflow: "贡献与协作流程"
-          DevStream Architecture: "DevStream 架构"
-          Environment Setup and Development: "环境搭建与开发"
-          Docs Contribution: "文档类贡献"
-          Helm Installer: "Helm 安装器"
-  - literate-nav
+- search:
+- i18n:
+    languages:
+      en: "English"
+      zh: "简体中文"
+    default_language: 'en'
+    no_translation:
+      en: "This page isn't translated to English."
+      zh: "这个页面还没有中文翻译。"
+    translate_nav:
+      en:
+        DTM Commands Explained in Depth: "DTM Commands Explained in Depth"
+        Plugins: "Plugins"
+        Best Practices: "Best Practices"
+        Developer Guide: "Developer Guide"
+        Core Concepts: "Core Concepts"
+        Commands: "Commands"
+        Contributor Ladder: "Contributor Ladder"
+        Road Map: "Road Map"
+        Code Review Guide: "Code Review Guide"
+        Overview: "Overview"
+        Contribute Workflow: "Contribute Workflow"
+        DevStream Architecture: "DevStream Architecture"
+        Environment Setup and Development: "Environment Setup and Development"
+        Docs Contribution: "Docs Contribution"
+        Helm Installer: "Helm Installer"
+      zh:
+        DTM Commands Explained in Depth: "DTM 命令详解"
+        Plugins: "插件"
+        Best Practices: "最佳实践"
+        Developer Guide: "开发指导"
+        Core Concepts: "核心概念"
+        Commands: "命令"
+        Contributor Ladder: "贡献者成长阶梯"
+        Road Map: "路线图"
+        Code Review Guide: "代码 review 指导"
+        Overview: "概览"
+        Contribute Workflow: "贡献与协作流程"
+        DevStream Architecture: "DevStream 架构"
+        Environment Setup and Development: "环境搭建与开发"
+        Docs Contribution: "文档类贡献"
+        Helm Installer: "Helm 安装器"
+- literate-nav
 nav:
-  - Overview: .
-  - understanding_the_basics*.md
-  - quickstart*.md
-  - install*.md
-  - Core Concepts:
-    - core-concepts/overview*.md
-    - core-concepts/tools-apps*.md
-    - core-concepts/state*.md
-    - core-concepts/config*.md
-    - core-concepts/output*.md
-  - Commands:
-    - commands/autocomplete*.md
-    - commands/*.md
-    - commands/develop*.md
-    - commands/verify*.md
-  - Plugins:
-    - plugins/plugins-list*.md
-    - Helm Installer:
-      - plugins/helm-installer/helm-installer*.md
-      - plugins/helm-installer/*.md
-    - plugins/*.md
-  - Best Practices: best-practices/
-  - contributing_guide*.md
-  - contributor_ladder*.md
-  - Governance ⧉: https://github.com/devstream-io/devstream/blob/main/GOVERNANCE.md
-  - PMC: pmc.md
-  - Developer Guide:
-    - Contribute Workflow:
-        - development/git-workflow/git-workflow*.md
-        - development/git-workflow/good-first-issue*.md
-        - development/git-workflow/help-wanted*.md
-        - development/git-workflow/commit-messages*.md
-        - development/git-workflow/branch-and-release*.md
-        - development/git-workflow/reviewing*.md
-    - DevStream Architecture:
-        - development/devstream/architecture*.md
-        - development/devstream/project-layout*.md
-    - Environment Setup and Development:
-        - development/dev/dev-env-setup*.md
-        - development/dev/lint*.md
-        - development/dev/build*.md
-        - development/dev/test*.md
-        - development/dev/creating-a-plugin*.md
-    - Docs Contribution:
-        - development/docs-contribution/mkdocs*.md
-        - development/docs-contribution/translation*.md
-  - Road Map ⧉: https://github.com/devstream-io/devstream/blob/main/ROADMAP.md
+- Overview: .
+- understanding_the_basics*.md
+- quickstart*.md
+- install*.md
+- Core Concepts:
+  - core-concepts/overview*.md
+  - core-concepts/tools-apps*.md
+  - core-concepts/state*.md
+  - core-concepts/config*.md
+  - core-concepts/output*.md
+- Commands:
+  - commands/autocomplete*.md
+  - commands/*.md
+  - commands/develop*.md
+  - commands/verify*.md
+- Plugins:
+  - plugins/plugins-list*.md
+  - Helm Installer:
+    - plugins/helm-installer/helm-installer*.md
+    - plugins/helm-installer/*.md
+  - plugins/*.md
+- Best Practices: best-practices/
+- contributing_guide*.md
+- contributor_ladder*.md
+- Governance ⧉: https://github.com/devstream-io/devstream/blob/main/GOVERNANCE.md
+- PMC: pmc.md
+- Developer Guide:
+  - Contribute Workflow:
+    - development/git-workflow/git-workflow*.md
+    - development/git-workflow/good-first-issue*.md
+    - development/git-workflow/help-wanted*.md
+    - development/git-workflow/commit-messages*.md
+    - development/git-workflow/branch-and-release*.md
+    - development/git-workflow/reviewing*.md
+  - DevStream Architecture:
+    - development/devstream/architecture*.md
+    - development/devstream/project-layout*.md
+  - Environment Setup and Development:
+    - development/dev/dev-env-setup*.md
+    - development/dev/lint*.md
+    - development/dev/build*.md
+    - development/dev/test*.md
+    - development/dev/creating-a-plugin*.md
+  - Docs Contribution:
+    - development/docs-contribution/mkdocs*.md
+    - development/docs-contribution/translation*.md
+- Road Map ⧉: https://github.com/devstream-io/devstream/blob/main/ROADMAP.md

--- a/test/e2e/yaml/e2e-config.yaml
+++ b/test/e2e/yaml/e2e-config.yaml
@@ -1,6 +1,5 @@
 varFile: e2e-variables.yaml
 toolFile: e2e-tools.yaml
-pluginDir: ""
 state:
   backend: local
   options:

--- a/test/e2e/yaml/e2e-trello-github-tools.yaml
+++ b/test/e2e/yaml/e2e-trello-github-tools.yaml
@@ -1,19 +1,19 @@
 tools:
-  - name: trello
-    instanceID: default
-    dependsOn: [ ]
-    options:
-      org: [[ githubOrganization ]]
-      repo: [[ repoName ]]
-      kanbanBoardName: [[ kanbanBoardName ]]
-  - name: trello-github-integ
-    instanceID: default
-    dependsOn: [ "trello.default" ]
-    options:
-      org: [[ githubOrganization ]]
-      repo: [[ repoName ]]
-      boardId: ${{ trello.default.outputs.boardId }}
-      todoListId: ${{ trello.default.outputs.todoListId }}
-      doingListId: ${{ trello.default.outputs.doingListId }}
-      doneListId: ${{ trello.default.outputs.doneListId }}
-      branch: main
+- name: trello
+  instanceID: default
+  dependsOn: [ ]
+  options:
+    org: [[ githubOrganization ]]
+    repo: [[ repoName ]]
+    kanbanBoardName: [[ kanbanBoardName ]]
+- name: trello-github-integ
+  instanceID: default
+  dependsOn: [ "trello.default" ]
+  options:
+    org: [[ githubOrganization ]]
+    repo: [[ repoName ]]
+    boardId: ${{ trello.default.outputs.boardId }}
+    todoListId: ${{ trello.default.outputs.todoListId }}
+    doingListId: ${{ trello.default.outputs.doingListId }}
+    doneListId: ${{ trello.default.outputs.doneListId }}
+    branch: main


### PR DESCRIPTION
## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

To further simplify the config file, we decided to use the default plugin directory "~/.devstream/plugins".

**Custom plugin directory is no longer supported in the config file.** If you do have a need to customize the plugin directory, you can still do so by using the `-d` flag. As for why we keep `-d`, on the one hand, the implementation of `-d` is very lightweight, almost one line of code, and this one line of code brings more flexibility and seems to be a good gain.

## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->

#1251 

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->

Custom plugin directory is no longer supported in the config file.