### PR TITLE
feat: all tools from apps depend on origin tools

### DIFF
--- a/internal/pkg/configmanager/config.go
+++ b/internal/pkg/configmanager/config.go
@@ -73,6 +73,14 @@ func (c *Config) getToolsWithVarsFromApp(a app) (Tools, error) {
 		tools = append(tools, repoScaffoldingTool)
 	}
 
+	// 5. all tools from apps should depend on the original tools,
+	//    because dtm will execute all original tools first, then execute all tools from apps
+	for _, toolFromApps := range tools {
+		for _, t := range c.Tools {
+			toolFromApps.DependsOn = append(toolFromApps.DependsOn, t.KeyWithNameAndInstanceID())
+		}
+	}
+
 	log.Debugf("Have got %d tools from app %s.", len(tools), rawApp.Name)
 	for i, t := range tools {
 		log.Debugf("Tool %d: %v", i+1, t)

--- a/internal/pkg/configmanager/configmanager_test.go
+++ b/internal/pkg/configmanager/configmanager_test.go
@@ -122,6 +122,8 @@ var _ = Describe("LoadConfig", func() {
 		InstanceID: "service-a",
 		DependsOn: []string{
 			"repo-scaffolding.service-a",
+			"plugin1.default",
+			"plugin2.tluafed",
 		},
 		Options: RawOptions{
 			"instanceID": "service-a",
@@ -152,6 +154,8 @@ var _ = Describe("LoadConfig", func() {
 		InstanceID: "service-a",
 		DependsOn: []string{
 			"repo-scaffolding.service-a",
+			"plugin1.default",
+			"plugin2.tluafed",
 		},
 		Options: RawOptions{
 			"instanceID": "service-a",
@@ -184,7 +188,10 @@ var _ = Describe("LoadConfig", func() {
 	tool5 := &Tool{
 		Name:       "repo-scaffolding",
 		InstanceID: "service-a",
-		DependsOn:  []string{},
+		DependsOn: []string{
+			"plugin1.default",
+			"plugin2.tluafed",
+		},
 		Options: RawOptions{
 			"instanceID": "service-a",
 			"destinationRepo": RawOptions{


### PR DESCRIPTION
Signed-off-by: Bird <aflybird0@gmail.com>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description

To make sure dtm will execute origin tools first, then tools from apps.

## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->
