### PR TITLE
fix: numeric type variables are parsed as strings

### DIFF
--- a/internal/pkg/configmanager/app_test.go
+++ b/internal/pkg/configmanager/app_test.go
@@ -1,0 +1,27 @@
+package configmanager
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("getToolsFromConfigFileWithVarsRendered", func() {
+	const appsConfig = `---
+apps:
+- name: app-1
+  cd:
+  - type: template
+    vars:
+      app: [[ appName ]]
+`
+	When("get apps from config file", func() {
+		It("should return config with vars", func() {
+			apps, err := getAppsFromConfigFileWithVarsRendered([]byte(appsConfig), map[string]any{"appName": interface{}("app-1")})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(apps).NotTo(BeNil())
+			Expect(len(apps)).To(Equal(1))
+			Expect(len(apps[0].CDRawConfigs)).To(Equal(1))
+			Expect(apps[0].CDRawConfigs[0].Vars["app"]).To(Equal(interface{}("app-1")))
+		})
+	})
+})

--- a/internal/pkg/configmanager/coreconfig.go
+++ b/internal/pkg/configmanager/coreconfig.go
@@ -1,5 +1,11 @@
 package configmanager
 
+import (
+	"gopkg.in/yaml.v3"
+
+	"github.com/devstream-io/devstream/pkg/util/file"
+)
+
 type CoreConfig struct {
 	State *State `yaml:"state"`
 }
@@ -22,4 +28,19 @@ type StateConfigOptions struct {
 	// for k8s backend
 	Namespace string `yaml:"namespace"`
 	ConfigMap string `yaml:"configmap"`
+}
+
+func getCoreConfigFromConfigFile(fileBytes []byte) (*CoreConfig, error) {
+	yamlPath := "$.config"
+	yamlStr, err := file.GetYamlNodeStrByPath(fileBytes, yamlPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var config *CoreConfig
+	err = yaml.Unmarshal([]byte(yamlStr), &config)
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
 }

--- a/internal/pkg/configmanager/coreconfig_test.go
+++ b/internal/pkg/configmanager/coreconfig_test.go
@@ -1,0 +1,25 @@
+package configmanager
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("getCoreConfigFromConfigFile", func() {
+	const configFile = `---
+config:
+  state:
+    backend: local
+    options:
+      stateFile: devstream.state
+`
+	When("get core config from config file", func() {
+		It("should works fine", func() {
+			cc, err := getCoreConfigFromConfigFile([]byte(configFile))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cc).NotTo(BeNil())
+			Expect(cc.State.Backend).To(Equal("local"))
+			Expect(cc.State.Options.StateFile).To(Equal("devstream.state"))
+		})
+	})
+})

--- a/internal/pkg/configmanager/pipelinetemplate.go
+++ b/internal/pkg/configmanager/pipelinetemplate.go
@@ -3,6 +3,8 @@ package configmanager
 import (
 	"fmt"
 
+	"github.com/devstream-io/devstream/pkg/util/file"
+
 	"github.com/imdario/mergo"
 	"gopkg.in/yaml.v3"
 
@@ -23,6 +25,29 @@ type (
 		Options RawOptions `yaml:"options"`
 	}
 )
+
+func getPipelineTemplatesMapFromConfigFile(fileBytes []byte) (map[string]string, error) {
+	yamlPath := "$.pipelineTemplates[*]"
+	yamlStrArray, err := file.GetYamlNodeArrayByPath(fileBytes, yamlPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if yamlStrArray == nil {
+		return make(map[string]string, 0), nil
+	}
+
+	var retMap = make(map[string]string)
+	for _, tplStr := range yamlStrArray.StrArray {
+		tplName, err := file.GetYamlNodeStrByPath([]byte(tplStr), "$.name")
+		if err != nil {
+			return nil, err
+		}
+		retMap[tplName] = tplStr
+	}
+
+	return retMap, nil
+}
 
 // getPipelineTemplate will generate pipleinTemplate from pipelineRaw
 func (p *pipelineRaw) getPipelineTemplate(templateMap map[string]string, globalVars map[string]any) (*pipelineTemplate, error) {

--- a/internal/pkg/configmanager/pipelinetemplate_test.go
+++ b/internal/pkg/configmanager/pipelinetemplate_test.go
@@ -85,7 +85,6 @@ var _ = Describe("pipelineRaw struct", func() {
 			It("should return err", func() {
 				_, err := r.getPipelineTemplate(templateMap, globalVars)
 				Expect(err).Error().Should(HaveOccurred())
-				Expect(err.Error()).Should(ContainSubstring("render pipelineTemplate failed"))
 			})
 		})
 		When("template is not valid yaml format", func() {
@@ -239,6 +238,29 @@ var _ = Describe("PipelineTemplate struct", func() {
 					},
 				}))
 			})
+		})
+	})
+})
+
+var _ = Describe("getPipelineTemplatesMapFromConfigFile", func() {
+	const toolsConfig = `pipelineTemplates:
+- name: tpl1
+  type: github-actions
+  options:
+    foo: bar
+`
+	const pipelineTemplate = `  name: tpl1
+  type: github-actions
+  options:
+    foo: bar`
+
+	When("get tools from config file", func() {
+		It("should return config with vars", func() {
+			pipelineTemplatesMap, err := getPipelineTemplatesMapFromConfigFile([]byte(toolsConfig))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pipelineTemplatesMap).NotTo(BeNil())
+			Expect(len(pipelineTemplatesMap)).To(Equal(1))
+			Expect(pipelineTemplatesMap["tpl1"]).To(Equal(pipelineTemplate))
 		})
 	})
 })

--- a/internal/pkg/configmanager/tool.go
+++ b/internal/pkg/configmanager/tool.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/devstream-io/devstream/internal/pkg/version"
+	"github.com/devstream-io/devstream/pkg/util/file"
 	"github.com/devstream-io/devstream/pkg/util/validator"
 )
 
@@ -43,6 +44,31 @@ func newTool(name, instanceID string, options RawOptions) *Tool {
 		DependsOn:  []string{},
 		Options:    options,
 	}
+}
+
+func getToolsFromConfigFileWithVarsRendered(fileBytes []byte, vars map[string]any) (Tools, error) {
+	yamlPath := "$.tools[*]"
+	yamlStrArray, err := file.GetYamlNodeArrayByPath(fileBytes, yamlPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if yamlStrArray == nil {
+		return make(Tools, 0), nil
+	}
+
+	yamlWithVars, err := renderConfigWithVariables(yamlStrArray.StrOrigin, vars)
+	if err != nil {
+		return nil, err
+	}
+
+	var retTools = make(Tools, 0)
+	err = yaml.Unmarshal(yamlWithVars, &retTools)
+	if err != nil {
+		return nil, err
+	}
+
+	return retTools, nil
 }
 
 func (t *Tool) String() string {

--- a/internal/pkg/configmanager/tool_test.go
+++ b/internal/pkg/configmanager/tool_test.go
@@ -139,3 +139,24 @@ var _ = Describe("Tool struct", func() {
 		})
 	})
 })
+
+var _ = Describe("getToolsFromConfigFileWithVarsRendered", func() {
+	const toolsConfig = `---
+tools:
+- name: name1
+  instanceID: ins-1
+  dependsOn: []
+  options:
+    foo: [[ foo ]]
+`
+	When("get tools from config file", func() {
+		It("should return config with vars", func() {
+			tools, err := getToolsFromConfigFileWithVarsRendered([]byte(toolsConfig), map[string]any{"foo": interface{}("bar")})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tools).NotTo(BeNil())
+			Expect(len(tools)).To(Equal(1))
+			Expect(len(tools[0].Options)).To(Equal(1))
+			Expect(tools[0].Options["foo"]).To(Equal(interface{}("bar")))
+		})
+	})
+})

--- a/internal/pkg/configmanager/variables.go
+++ b/internal/pkg/configmanager/variables.go
@@ -1,11 +1,32 @@
 package configmanager
 
 import (
+	"gopkg.in/yaml.v3"
+
+	"github.com/devstream-io/devstream/pkg/util/file"
 	"github.com/devstream-io/devstream/pkg/util/log"
 	"github.com/devstream-io/devstream/pkg/util/template"
 )
 
+func getVarsFromConfigFile(fileBytes []byte) (map[string]any, error) {
+	yamlPath := "$.vars"
+	yamlStr, err := file.GetYamlNodeStrByPath(fileBytes, yamlPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var retMap = make(map[string]any)
+	err = yaml.Unmarshal([]byte(yamlStr), retMap)
+	if err != nil {
+		return nil, err
+	}
+	return retMap, nil
+}
+
 func renderConfigWithVariables(fileContent string, variables map[string]interface{}) ([]byte, error) {
+	if len(variables) == 0 {
+		return []byte(fileContent), nil
+	}
 	logFunc(fileContent, variables)
 
 	str, err := template.New().

--- a/internal/pkg/configmanager/variables_test.go
+++ b/internal/pkg/configmanager/variables_test.go
@@ -24,3 +24,23 @@ var _ = Describe("renderConfigWithVariables", func() {
 		})
 	})
 })
+
+var _ = Describe("getVarsFromConfigFile", func() {
+	const configFile = `---
+foo: bar
+vars:
+  foo1: bar1
+  foo2: 123
+foo3: bar3
+`
+	When("get vars from config file", func() {
+		It("should works fine", func() {
+			varMap, err := getVarsFromConfigFile([]byte(configFile))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(varMap).NotTo(BeNil())
+			Expect(len(varMap)).To(Equal(2))
+			Expect(varMap["foo1"]).To(Equal(interface{}("bar1")))
+			Expect(varMap["foo2"]).To(Equal(interface{}(123)))
+		})
+	})
+})

--- a/pkg/util/file/yaml.go
+++ b/pkg/util/file/yaml.go
@@ -48,9 +48,9 @@ func GetYamlNodeArrayByPath(content []byte, path string) (*YamlSequenceNode, err
 	if !ok {
 		return nil, fmt.Errorf("yaml parse path[%s] is not valid sequenceNode", string(content))
 	}
-	var nodeArray []string
-	for _, seqNode := range seqNode.Values {
-		nodeArray = append(nodeArray, seqNode.String())
+	var nodeArray = make([]string, 0)
+	for _, sn := range seqNode.Values {
+		nodeArray = append(nodeArray, sn.String())
 	}
 	y := &YamlSequenceNode{
 		StrOrigin: node.String(),

--- a/pkg/util/template/processor.go
+++ b/pkg/util/template/processor.go
@@ -4,7 +4,7 @@ import "regexp"
 
 // this is because our variables' syntax is [[ varName ]]
 // while Go's template is [[ .varName ]]
-func AddDotForVariablesInConfig(s string) string {
+func addDotForVariablesInConfig(s string) string {
 	// regex := `\[\[\s*(.*)\s*\]\]`
 	// r := regexp.MustCompile(regex)
 	// return r.ReplaceAllString(s, "[[ .$1 ]]")
@@ -15,11 +15,9 @@ func AddDotForVariablesInConfig(s string) string {
 
 func AddDotForVariablesInConfigProcessor() Processor {
 	return func(bytes []byte) ([]byte, error) {
-		return []byte(AddDotForVariablesInConfig(string(bytes))), nil
+		return []byte(addDotForVariablesInConfig(string(bytes))), nil
 	}
 }
-
-// Quick Calls
 
 func (r *rendererWithGetter) AddDotForVariablesInConfigProcessor() *rendererWithGetter {
 	return r.AddProcessor(AddDotForVariablesInConfigProcessor())

--- a/pkg/util/template/processor_test.go
+++ b/pkg/util/template/processor_test.go
@@ -7,21 +7,21 @@ import (
 )
 
 func TestAddDotForVariablesInConfigNormal(t *testing.T) {
-	res := AddDotForVariablesInConfig("[[varNameA]]")
+	res := addDotForVariablesInConfig("[[varNameA]]")
 	assert.Equal(t, "[[ .varNameA]]", res, "Adding dot for variable names passed.")
 }
 
 func TestAddDotForVariablesInConfigWithSpaces(t *testing.T) {
-	res := AddDotForVariablesInConfig("[[  varNameA]]")
+	res := addDotForVariablesInConfig("[[  varNameA]]")
 	assert.Equal(t, "[[ .varNameA]]", res, "Adding dot for variable names passed.")
 }
 
 func TestAddDotForVariablesInConfigWithTrailingSpaces(t *testing.T) {
-	res := AddDotForVariablesInConfig("[[ varNameA  ]]")
+	res := addDotForVariablesInConfig("[[ varNameA  ]]")
 	assert.Equal(t, "[[ .varNameA  ]]", res, "Adding dot for variable names passed.")
 }
 
 func TestAddDotForVariablesInConfigMultipleVars(t *testing.T) {
-	res := AddDotForVariablesInConfig("[[ varNameA ]]/[[ varNameB ]]/[[ varNameC ]]")
+	res := addDotForVariablesInConfig("[[ varNameA ]]/[[ varNameB ]]/[[ varNameC ]]")
 	assert.Equal(t, "[[ .varNameA ]]/[[ .varNameB ]]/[[ .varNameC ]]", res, "Adding dot for variable names passed.")
 }


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

Fixed the bug: numeric type variables are parsed as strings

## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->

close #1260

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->

bugfixed

## TODO

`foo: [[ var1 ]]/[[ var2 ]]` support @steinliber 

## Test

- config

```yaml
config:
  state:
    backend: local
    options:
      stateFile: devstream.state

vars:
  gitlabHostname: gitlab.example.com
  jenkinsHostname: jenkins.example.com
  harborHostname: harbor.example.com
  harborURL: http://harbor.example.com
  jenkinsAdminUser: admin
  jenkinsAdminPassword: changeme
  gitlabSSHPort: 30022
  gitlabHttpPort: 30080
  gitlabHttpsPort: 30443

tools:
- name: gitlab-ce-docker
  instanceID: default
  dependsOn: []
  options:
    hostname: [[ gitlabHostname ]]
    gitlabHome: /srv/gitlab
    sshPort: [[ gitlabSSHPort ]]
    httpPort: [[ gitlabHttpPort ]]
    httpsPort: [[ gitlabHttpsPort ]]
    rmDataAfterDelete: false
    imageTag: "rc"
- name: helm-installer
  instanceID: jenkins-001
  dependsOn: []
  options:
    valuesYaml: |
      serviceAccount:
        create: true
        name: jenkins
      controller:
        adminUser: [[ jenkinsAdminUser ]]
        adminPassword: [[ jenkinsAdminPassword ]]
        ingress:
          enabled: true
          hostName: [[ jenkinsHostname ]]
      enableRawHtmlMarkupFormatter: true
      JCasC:
        defaultConfig: true
- name: helm-installer
  instanceID: harbor-001
  dependsOn: []
  options:
    valuesYaml: |
      externalURL: [[ harborURL ]]
      expose:
        type: ingress
        tls:
          enabled: false
        ingress:
          hosts:
            core: [[ harborHostname ]]
      chartmuseum:
        enabled: false
      notary:
        enabled: false
      trivy:
        enabled: false
      persistence:
        persistentVolumeClaim:
          registry:
            storageClass: ""
            accessMode: ReadWriteOnce
            size: 5Gi
          jobservice:
            storageClass: ""
            accessMode: ReadWriteOnce
            size: 1Gi
          database:
            storageClass: ""
            accessMode: ReadWriteOnce
            size: 1Gi
          redis:
            storageClass: ""
            accessMode: ReadWriteOnce
            size: 1Gi
```

- `dtm apply -f config-tools.yaml -y`

```sh
2022-11-28 12:12:06 ℹ [INFO]  Apply started.
2022-11-28 12:12:06 ℹ [INFO]  Using local backend. State file: devstream.state.
2022-11-28 12:12:06 ℹ [INFO]  Tool (gitlab-ce-docker/default) found in config but doesn't exist in the state, will be created.
2022-11-28 12:12:06 ℹ [INFO]  Tool (helm-installer/jenkins-001) found in config but doesn't exist in the state, will be created.
2022-11-28 12:12:06 ℹ [INFO]  Tool (helm-installer/harbor-001) found in config but doesn't exist in the state, will be created.
2022-11-28 12:12:06 ℹ [INFO]  Start executing the plan.
2022-11-28 12:12:06 ℹ [INFO]  Changes count: 3.
2022-11-28 12:12:06 ℹ [INFO]  -------------------- [  Processing progress: 1/3.  ] --------------------
2022-11-28 12:12:06 ℹ [INFO]  Processing: (gitlab-ce-docker/default) -> Create ...
2022-11-28 12:12:06 ℹ [INFO]  Cmd: docker image ls gitlab/gitlab-ce:rc -q.
2022-11-28 12:12:06 ℹ [INFO]  Cmd: docker pull gitlab/gitlab-ce:rc.
Stdout: rc: Pulling from gitlab/gitlab-ce
...
Stdout: Digest: sha256:e7daa93f8bb2b0176a62d0e80b68a708fc57a5e6d77a9c8ed8f3e3037da66daf
Stdout: Status: Downloaded newer image for gitlab/gitlab-ce:rc
Stdout: docker.io/gitlab/gitlab-ce:rc
2022-11-28 12:12:34 ℹ [INFO]  Running container as the name <gitlab>
2022-11-28 12:12:34 ℹ [INFO]  Cmd: docker run --detach --hostname gitlab.example.com --publish 30022:22 --publish 30080:80 --publish 30443:443 --name gitlab --restart always --volume /srv/gitlab/config:/etc/gitlab --volume /srv/gitlab/data:/var/opt/gitlab --volume /srv/gitlab/logs:/var/log/gitlab gitlab/gitlab-ce:rc.
Stdout: 899c909cc7fcb2c47536abd38e7e8f6ae141542e79c4b37748ddc6cfd26dd197
2022-11-28 12:12:39 ℹ [INFO]  Cmd: docker inspect --format='{{json .Mounts}}' gitlab.
2022-11-28 12:12:39 ℹ [INFO]  GitLab access URL: http://gitlab.example.com:30080
2022-11-28 12:12:39 ℹ [INFO]  GitLab initial root password: execute the command -> docker exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
2022-11-28 12:12:39 ✔ [SUCCESS]  Tool (gitlab-ce-docker/default) Create done.
2022-11-28 12:12:39 ℹ [INFO]  -------------------- [  Processing progress: 2/3.  ] --------------------
2022-11-28 12:12:39 ℹ [INFO]  Processing: (helm-installer/jenkins-001) -> Create ...
2022-11-28 12:12:40 ℹ [INFO]  Filling default config with instance: jenkins-001.
2022-11-28 12:12:40 ℹ [INFO]  Creating or updating helm chart ...
2022/11/28 12:12:41 creating 13 resource(s)
2022/11/28 12:12:41 beginning wait for 13 resources with timeout of 10m0s
2022/11/28 12:12:41 StatefulSet is not ready: jenkins/jenkins. 0 out of 1 expected pods are ready
...
2022/11/28 12:13:21 StatefulSet is not ready: jenkins/jenkins. 0 out of 1 expected pods are ready
2022/11/28 12:13:23 release installed successfully: jenkins/jenkins-4.2.15
2022-11-28 12:13:23 ✔ [SUCCESS]  Tool (helm-installer/jenkins-001) Create done.
2022-11-28 12:13:23 ℹ [INFO]  -------------------- [  Processing progress: 3/3.  ] --------------------
2022-11-28 12:13:23 ℹ [INFO]  Processing: (helm-installer/harbor-001) -> Create ...
2022-11-28 12:13:23 ℹ [INFO]  Filling default config with instance: harbor-001.
2022-11-28 12:13:23 ℹ [INFO]  Creating or updating helm chart ...
2022/11/28 12:13:24 creating 28 resource(s)
2022/11/28 12:13:24 beginning wait for 28 resources with timeout of 10m0s
2022/11/28 12:13:24 Deployment is not ready: harbor/harbor-core. 0 out of 1 expected pods are ready
...
2022/11/28 12:15:12 Deployment is not ready: harbor/harbor-jobservice. 0 out of 1 expected pods are ready
2022/11/28 12:15:15 release installed successfully: harbor/harbor-1.10.2
2022-11-28 12:15:15 ✔ [SUCCESS]  Tool (helm-installer/harbor-001) Create done.
2022-11-28 12:15:15 ℹ [INFO]  -------------------- [  Processing done.  ] --------------------
2022-11-28 12:15:15 ✔ [SUCCESS]  All plugins applied successfully.
2022-11-28 12:15:15 ✔ [SUCCESS]  Apply finished.
```