### PR TITLE
fix: greedy matching problem of helm-installer plugin

### DIFF
--- a/internal/pkg/plugin/helminstaller/create.go
+++ b/internal/pkg/plugin/helminstaller/create.go
@@ -12,13 +12,13 @@ func Create(options configmanager.RawOptions) (statemanager.ResourceStatus, erro
 	// Initialize Operator with Operations
 	operator := &installer.Operator{
 		PreExecuteOperations: installer.PreExecuteOperations{
-			RenderDefaultConfig,
-			RenderValuesYaml,
+			renderDefaultConfig,
+			renderValuesYaml,
 			validate,
 		},
 		ExecuteOperations:   helm.DefaultCreateOperations,
 		TerminateOperations: helm.DefaultTerminateOperations,
-		GetStatusOperation:  IndexStatusGetterFunc(options),
+		GetStatusOperation:  indexStatusGetterFunc(options),
 	}
 
 	// Execute all Operations in Operator

--- a/internal/pkg/plugin/helminstaller/defaults/defaultconfig.go
+++ b/internal/pkg/plugin/helminstaller/defaults/defaultconfig.go
@@ -5,5 +5,7 @@ import (
 	"github.com/devstream-io/devstream/internal/pkg/plugin/installer/helm"
 )
 
-var DefaultOptionsMap = make(map[string]*helm.Options)
-var StatusGetterFuncMap = make(map[string]installer.StatusGetterOperation)
+var (
+	DefaultOptionsMap   = make(map[string]*helm.Options)
+	StatusGetterFuncMap = make(map[string]installer.StatusGetterOperation)
+)

--- a/internal/pkg/plugin/helminstaller/delete.go
+++ b/internal/pkg/plugin/helminstaller/delete.go
@@ -10,8 +10,8 @@ func Delete(options configmanager.RawOptions) (bool, error) {
 	// Initialize Operator with Operations
 	operator := &installer.Operator{
 		PreExecuteOperations: installer.PreExecuteOperations{
-			RenderDefaultConfig,
-			RenderValuesYaml,
+			renderDefaultConfig,
+			renderValuesYaml,
 			validate,
 		},
 		ExecuteOperations: helm.DefaultDeleteOperations,

--- a/internal/pkg/plugin/helminstaller/helminstaller.go
+++ b/internal/pkg/plugin/helminstaller/helminstaller.go
@@ -88,7 +88,7 @@ func getDefaultOptionsByInstanceID(instanceID string) *helm.Options {
 	// e.g. argocd-config-001 contains argocd and argocd-config, so the argocd and argocd-config both are matched name.
 	var matchedNames = make([]string, 0)
 	for name := range defaults.DefaultOptionsMap {
-		if strings.Contains(instanceID, name) {
+		if strings.HasPrefix(instanceID, name) {
 			matchedNames = append(matchedNames, name)
 		}
 	}

--- a/internal/pkg/plugin/helminstaller/read.go
+++ b/internal/pkg/plugin/helminstaller/read.go
@@ -11,11 +11,11 @@ func Read(options configmanager.RawOptions) (statemanager.ResourceStatus, error)
 	// Initialize Operator with Operations
 	operator := &installer.Operator{
 		PreExecuteOperations: installer.PreExecuteOperations{
-			RenderDefaultConfig,
-			RenderValuesYaml,
+			renderDefaultConfig,
+			renderValuesYaml,
 			validate,
 		},
-		GetStatusOperation: IndexStatusGetterFunc(options),
+		GetStatusOperation: indexStatusGetterFunc(options),
 	}
 
 	// Execute all Operations in Operator

--- a/internal/pkg/plugin/helminstaller/update.go
+++ b/internal/pkg/plugin/helminstaller/update.go
@@ -12,13 +12,13 @@ func Update(options configmanager.RawOptions) (statemanager.ResourceStatus, erro
 	// Initialize Operator with Operations
 	operator := &installer.Operator{
 		PreExecuteOperations: installer.PreExecuteOperations{
-			RenderDefaultConfig,
-			RenderValuesYaml,
+			renderDefaultConfig,
+			renderValuesYaml,
 			validate,
 		},
 		ExecuteOperations:   helm.DefaultUpdateOperations,
 		TerminateOperations: helm.DefaultTerminateOperations,
-		GetStatusOperation:  IndexStatusGetterFunc(options),
+		GetStatusOperation:  indexStatusGetterFunc(options),
 	}
 
 	// Execute all Operations in Operator


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

e.g. instanceID="argocd-config-001", "argocd" and "argocd-config" both are supported helm charts, then dtm should know that it is a argocd-config instance.

## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->

N/A

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->

instanceID becomes more accurate in helm-installer plugin.