### PR TITLE
feat: jenkins pipeline support offline

### DIFF
--- a/internal/pkg/plugin/installer/ci/ci.go
+++ b/internal/pkg/plugin/installer/ci/ci.go
@@ -49,14 +49,13 @@ func (p *PipelineConfig) BuildCIFileConfig(ciType server.CIServerType, repoInfo 
 		ConfigLocation: downloader.ResourceLocation(p.ConfigLocation),
 	}
 	// update ci render variables by plugins
-	rawConfigVars := p.generateCIFileVars(repoInfo)
-	rawConfigVars.Set("AppName", repoInfo.Repo)
+	rawConfigVars := p.GenerateCIFileVars(repoInfo)
 	CIFileConfig.Vars = rawConfigVars
 	log.Debugf("gitlab-ci pipeline get render vars: %+v", CIFileConfig)
 	return CIFileConfig
 }
 
-func (p *PipelineConfig) generateCIFileVars(repoInfo *git.RepoInfo) cifile.CIFileVarsMap {
+func (p *PipelineConfig) GenerateCIFileVars(repoInfo *git.RepoInfo) cifile.CIFileVarsMap {
 	// set default command for language
 	p.setDefault()
 	varMap, _ := mapz.DecodeStructToMap(p)
@@ -67,6 +66,7 @@ func (p *PipelineConfig) generateCIFileVars(repoInfo *git.RepoInfo) cifile.CIFil
 	if err != nil {
 		log.Warnf("cifile merge CIFileVarsMap failed: %+v", err)
 	}
+	varMap["AppName"] = repoInfo.Repo
 	return varMap
 }
 

--- a/internal/pkg/plugin/installer/ci/ci_test.go
+++ b/internal/pkg/plugin/installer/ci/ci_test.go
@@ -80,7 +80,7 @@ var _ = Describe("PipelineConfig struct", func() {
 		})
 	})
 	It("should return file Vars", func() {
-		varMap := a.generateCIFileVars(r)
+		varMap := a.GenerateCIFileVars(r)
 		var emptyDingtalk *step.DingtalkStepConfig
 		var emptySonar *step.SonarQubeStepConfig
 		var emptyBool *bool
@@ -90,6 +90,7 @@ var _ = Describe("PipelineConfig struct", func() {
 			"DingTalkSecretToken":   "DINGTALK_SECURITY_TOKEN",
 			"ImageRepoSecret":       "IMAGE_REPO_SECRET",
 			"ImageRepoDockerSecret": "image-repo-auth",
+			"AppName":               "test_repo",
 			"StepGlobalVars":        "",
 			"RepoType":              "gitlab",
 			"imageRepo": map[string]interface{}{

--- a/internal/pkg/plugin/jenkinspipeline/option.go
+++ b/internal/pkg/plugin/jenkinspipeline/option.go
@@ -99,6 +99,14 @@ func (j *jobOptions) extractPlugins() []step.StepConfigAPI {
 	return stepConfigs
 }
 
+// check config need offline config
+func (j *jobOptions) needOfflineConfig() bool {
+	// since we use github as default config location
+	// we use this to check whether this pipeline need default offline Jenkinsfile
+	const githubContentHost = "raw.githubusercontent.com"
+	return j.Jenkins.Offline && strings.Contains(string(j.Pipeline.ConfigLocation), githubContentHost)
+}
+
 // jenkins jobName, can be like folder/jobName or jobName
 type jenkinsJobName string
 

--- a/internal/pkg/plugin/jenkinspipeline/validate.go
+++ b/internal/pkg/plugin/jenkinspipeline/validate.go
@@ -1,11 +1,17 @@
 package jenkinspipeline
 
 import (
+	_ "embed"
+
 	"github.com/devstream-io/devstream/internal/pkg/configmanager"
+	"github.com/devstream-io/devstream/internal/pkg/plugin/installer/ci/cifile"
 	"github.com/devstream-io/devstream/pkg/util/log"
 	"github.com/devstream-io/devstream/pkg/util/types"
 	"github.com/devstream-io/devstream/pkg/util/validator"
 )
+
+//go:embed tpl/Jenkinsfile_offline.tpl
+var offlineJenkinsScript string
 
 // setJenkinsDefault config default fields for usage
 func setJenkinsDefault(options configmanager.RawOptions) (configmanager.RawOptions, error) {
@@ -19,7 +25,18 @@ func setJenkinsDefault(options configmanager.RawOptions) (configmanager.RawOptio
 		return nil, err
 	}
 	opts.ProjectRepo = projectRepo
-	opts.CIFileConfig = opts.Pipeline.BuildCIFileConfig(ciType, projectRepo)
+	// if jenkins is offline, just use offline Jenkinsfile
+	if opts.needOfflineConfig() {
+		opts.CIFileConfig = &cifile.CIFileConfig{
+			Type: ciType,
+			ConfigContentMap: map[string]string{
+				"Jenkinsfile": offlineJenkinsScript,
+			},
+			Vars: opts.Pipeline.GenerateCIFileVars(projectRepo),
+		}
+	} else {
+		opts.CIFileConfig = opts.Pipeline.BuildCIFileConfig(ciType, projectRepo)
+	}
 	// set field value if empty
 	if opts.Jenkins.Namespace == "" {
 		opts.Jenkins.Namespace = "jenkins"


### PR DESCRIPTION
Signed-off-by: Meng JiaFeng <jiafeng.meng@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [ ] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [ ] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description
- jenkins support new option `offline` for config offline
### offline mode
- jenkins will not check and install plugins, so you need to build a jenkins image with plugins instqalled first
- jenkins will not use global share library, instead we upload Jenkinsfile to repo 

### online mode
- jenkins will check plugins and automatic install plugins 
- jenkins will use sharelib for common jenkins step

## Related Issues
#1239 

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->
