### PR TITLE
fix: e2e test error in ci file getter

### DIFF
--- a/internal/pkg/configmanager/pipelineDefault.go
+++ b/internal/pkg/configmanager/pipelineDefault.go
@@ -24,7 +24,7 @@ type pipelineOption struct {
 var (
 	// github actions pipeline options
 	githubGeneral = pipelineOption{
-		defaultConfigLocation: "git@github.com:devstream-io/ci-template.git//github-actions",
+		defaultConfigLocation: "https://raw.githubusercontent.com/devstream-io/ci-template/main/github-actions/workflows/main.yml",
 		optionGeneratorFunc:   pipelineGeneralGenerator,
 	}
 	gitlabGeneral = pipelineOption{


### PR DESCRIPTION
Signed-off-by: Meng JiaFeng <jiafeng.meng@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [ ] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [ ] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description
- use https to get github-actions file
- pass e2e test for github action doesn't has public key

## Related Issues
#1239

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->
