### PR TITLE
chore: logging improvement for invalid configuration

### DIFF
--- a/cmd/devstream/apply.go
+++ b/cmd/devstream/apply.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -23,6 +24,9 @@ func applyCMDFunc(cmd *cobra.Command, args []string) {
 	log.Info("Apply started.")
 	if err := pluginengine.Apply(configFilePath, continueDirectly); err != nil {
 		log.Errorf("Apply failed => %s.", err)
+		if strings.Contains(err.Error(), "config not valid") {
+			log.Info("It seems your config file is not valid. Please check the official documentation https://docs.devstream.io, or use the \"dtm show config\" command to get an example.")
+		}
 		os.Exit(1)
 	}
 	log.Success("Apply finished.")

--- a/internal/pkg/configmanager/rawconfig.go
+++ b/internal/pkg/configmanager/rawconfig.go
@@ -59,7 +59,7 @@ func newRawConfigFromConfigBytes(fileText []byte) (*rawConfig, error) {
 
 // validate will check config data is valid
 func (c *rawConfig) validate() error {
-	errorFmt := "configmanager can't found valid [%s], please check your config file"
+	errorFmt := "config not valid; check the [%s] section of your config file"
 	if (len(c.config)) == 0 {
 		return fmt.Errorf(errorFmt, "config")
 	}

--- a/internal/pkg/configmanager/rawconfig_test.go
+++ b/internal/pkg/configmanager/rawconfig_test.go
@@ -69,7 +69,7 @@ var _ = Describe("rawConfig struct", func() {
 			It("should return error", func() {
 				e := r.validate()
 				Expect(e).Error().Should(HaveOccurred())
-				Expect(e.Error()).Should(Equal("configmanager can't found valid [config], please check your config file"))
+				Expect(e.Error()).Should(Equal("config not valid; check the [config] section of your config file"))
 			})
 		})
 		When("apps and tools is not exist", func() {
@@ -81,7 +81,7 @@ var _ = Describe("rawConfig struct", func() {
 			It("should return error", func() {
 				e := r.validate()
 				Expect(e).Error().Should(HaveOccurred())
-				Expect(e.Error()).Should(Equal("configmanager can't found valid [tools and apps], please check your config file"))
+				Expect(e.Error()).Should(Equal("config not valid; check the [tools and apps] section of your config file"))
 			})
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Tiexin Guo <guotiexin@gmail.com>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description

## 1 Wrong Config

Config:

```yaml
asdf
```

Original behaviour:

```bash
tiexin@mbp ~/work/devstream-io/devstream $ ./dtm apply
2022-12-08 11:15:00 ℹ [INFO]  Apply started.
2022-12-08 11:15:00 !! [ERROR]  Apply failed => configmanager can't found valid [config], please check your config file.
```

After fix:

```bash
tiexin@mbp ~/work/devstream-io/devstream $ ./dtm apply
2022-12-08 11:27:27 ℹ [INFO]  Apply started.
2022-12-08 11:27:27 !! [ERROR]  Apply failed => config not valid; check the [config] section of your config file.
2022-12-08 11:27:27 ℹ [INFO]  It seems your config file is not valid. Please check the official documentation https://docs.devstream.io, or use the "dtm show config" command to get an example.
```

## 2 Missing Variable Definition

Config:

```yaml
config:
  state:
    backend: local
    options:
      stateFile: devstream.state

tools:
- name: repo-scaffolding
  instanceID: myapp
  options:
    vars:
      imageRepo: [[ dockerUser ]]/[[ app ]]
```


Original behaviour:

```bash
tiexin@mbp ~/work/devstream-io/devstream $ ./dtm apply
2022-12-08 11:30:52 ℹ [INFO]  Apply started.
2022-12-08 11:30:52 !! [ERROR]  Apply failed => failed to get tools from config file. Error: template:
- name: repo-scaffolding
  instanceID: myapp
  options:
    vars:
      imageRepo: [[ dockerUser ]]/[[ app ]]
:6:20: executing "\n- name: repo-scaffolding\n  instanceID: myapp\n  options:\n    vars:\n      imageRepo: [[ dockerUser ]]/[[ app ]]\n" at <.dockerUser>: map has no entry for key "dockerUser".
```

After fix:

```bash
tiexin@mbp ~/work/devstream-io/devstream $ ./dtm apply
2022-12-08 11:44:30 ℹ [INFO]  Apply started.
2022-12-08 11:44:30 !! [ERROR]  Apply failed => failed to process variables in the tools section. Missing variable definition: "dockerUser".
```