### PR TITLE
feat: check if the number of plugins on s3 is correct

### DIFF
--- a/hack/release/auto-release-darwin-arm64.sh
+++ b/hack/release/auto-release-darwin-arm64.sh
@@ -71,3 +71,17 @@ echo "${DTM_CORE_BINARY} uploaded."
 # After downloading aws cli, you need to configure aws credentials.
 pip3 install awscli
 aws s3 cp $plugin_dir $STORAGE_URL_WITH_TAG --recursive --acl public-read
+
+# check if the number of plugins on s3 is correct
+local_plugin_nums=$(./dtm list plugins |wc -l)
+((local_plugin_file_nums=local_plugin_nums*6))
+s3_plugin_file_total_nums=$(aws s3 ls download.devstream.io/"$tag"/|awk '{print $NF}'|uniq|wc -l)
+((s3_plugin_file_nums=s3_plugin_file_total_nums-3))
+echo "$s3_plugin_file_nums"
+echo "$local_plugin_file_nums"
+if [ "$local_plugin_file_nums" -ne "$s3_plugin_file_nums" ]
+then
+  echo "Attention,Maybe the plugin uploaded to s3 is not correct."
+else
+  echo "The plugin uploaded to s3 is not correct."
+fi

--- a/hack/release/auto-release-darwin-arm64.sh
+++ b/hack/release/auto-release-darwin-arm64.sh
@@ -73,15 +73,15 @@ pip3 install awscli
 aws s3 cp $plugin_dir $STORAGE_URL_WITH_TAG --recursive --acl public-read
 
 # check if the number of plugins on s3 is correct
-local_plugin_nums=$(./dtm list plugins |wc -l)
+local_plugin_nums=$(../../dtm list plugins |wc -l)
 ((local_plugin_file_nums=local_plugin_nums*6))
 s3_plugin_file_total_nums=$(aws s3 ls download.devstream.io/"$tag"/|awk '{print $NF}'|uniq|wc -l)
 ((s3_plugin_file_nums=s3_plugin_file_total_nums-3))
-echo "$s3_plugin_file_nums"
-echo "$local_plugin_file_nums"
+echo "s3_plugin_file_nums:" "$s3_plugin_file_nums"
+echo "local_plugin_file_nums:" "$local_plugin_file_nums"
 if [ "$local_plugin_file_nums" -ne "$s3_plugin_file_nums" ]
 then
   echo "Attention,Maybe the plugin uploaded to s3 is not correct."
 else
-  echo "The plugin uploaded to s3 is not correct."
+  echo "The plugin uploaded to s3 is correct."
 fi


### PR DESCRIPTION
Signed-off-by: KeHaoKH <hao.ke@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
check if the number of plugins on s3 is correct.
By calculating the total number of local plugin files and comparing it with the total number of plugins in the corresponding directory of s3 (minus the number of dtm files for 3 platforms, i.e. 3), if they are not equal, an error message is returned after script execution.

## New Behavior (screenshots if needed)
I took out the relevant pieces of logic in the script, named it a test script, and tested the results as follows:

![image](https://user-images.githubusercontent.com/103085894/206527887-c386537a-066a-4a46-9581-82e46a0c2211.png)






