### PR TITLE
fix: scm cant get repo name when use url

### DIFF
--- a/internal/pkg/plugin/installer/reposcaffolding/option.go
+++ b/internal/pkg/plugin/installer/reposcaffolding/option.go
@@ -24,9 +24,9 @@ func NewOptions(options configmanager.RawOptions) (*Options, error) {
 func (opts *Options) renderTplConfig() map[string]interface{} {
 	// default render value from repo
 	renderConfig := map[string]any{
-		"AppName": opts.DestinationRepo.Repo,
+		"AppName": opts.DestinationRepo.GetRepoName(),
 		"Repo": map[string]string{
-			"Name":  opts.DestinationRepo.Repo,
+			"Name":  opts.DestinationRepo.GetRepoName(),
 			"Owner": opts.DestinationRepo.GetRepoOwner(),
 		},
 	}

--- a/pkg/util/scm/git/repoinfo_test.go
+++ b/pkg/util/scm/git/repoinfo_test.go
@@ -397,6 +397,18 @@ var _ = Describe("ScmURL type", func() {
 					Expect(err.Error()).Should(ContainSubstring("git url repo path is not valid"))
 				})
 			})
+			When("url is path doesn't have scheme", func() {
+				BeforeEach(func() {
+					cloneURL = "test.com/test_user/test_repo"
+				})
+				It("should add scheme auto", func() {
+					owner, repo, err := cloneURL.extractRepoOwnerAndName()
+					Expect(err).Error().ShouldNot(HaveOccurred())
+					Expect(owner).Should(Equal("test_user"))
+					Expect(repo).Should(Equal("test_repo"))
+				})
+			})
+
 		})
 		When("cloneURL is git ssh format", func() {
 			When("ssh format is valid", func() {


### PR DESCRIPTION
Signed-off-by: Meng JiaFeng <jiafeng.meng@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description
- fix reposcaffolding in render variables when get repo name
- fix repoInfo get name empty when use url

## Related Issues
close #1352

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->
