### PR TITLE
feat: use config field instead of env

### DIFF
--- a/examples/apps.yaml
+++ b/examples/apps.yaml
@@ -19,6 +19,7 @@ apps:
     framework: django
   repo:
     url: github.com/[[ GITHUB_USER ]]/myapp1
+    token: [[ env GITHUB_TOKEN ]]
   repoTemplate:
     url: github.com/devstream-io/dtm-repo-scaffolding-python-flask
   ci:
@@ -26,6 +27,7 @@ apps:
     options:
       imageRepo:
         user: [[ DOCKERHUB_USER ]]
+        password: [[ env IMAGE_REPO_PASSWORD ]]
   cd:
   - type: argocdapp
 - name: myapp2
@@ -34,6 +36,7 @@ apps:
     framework: gin
   repo:
     url: github.com/[[ GITHUB_USER ]]/myapp2
+    token: [[ env GITHUB_TOKEN ]]
   repoTemplate:
     url: github.com/devstream-io/dtm-repo-scaffolding-golang-gin
   ci:
@@ -41,5 +44,6 @@ apps:
     options:
       imageRepo:
         user: [[ DOCKERHUB_USER ]]
+        password: [[ env IMAGE_REPO_PASSWORD ]]
   cd:
   - type: argocdapp

--- a/examples/gitops.yaml
+++ b/examples/gitops.yaml
@@ -17,6 +17,7 @@ tools:
       name: [[ app ]]
       branch: main
       scmType: github
+      token: [[ env GITHUB_TOKEN ]]
     sourceRepo:
       org: devstream-io
       name: dtm-repo-scaffolding-python-flask
@@ -29,6 +30,7 @@ tools:
       owner: [[ githubUser ]]
       name:  [[ app ]]
       scmType: github
+      token: [[ env GITHUB_TOKEN ]]
     pipeline:
       configLocation: https://raw.githubusercontent.com/devstream-io/dtm-pipeline-templates/main/github-actions/workflows/main.yml
       language:
@@ -36,6 +38,7 @@ tools:
         framework: flask
       imageRepo:
         user: [[ dockerUser ]]
+        password: [[ env IMAGE_REPO_PASSWORD ]]
 - name: helm-installer
   instanceID: argocd
 - name: argocdapp
@@ -52,5 +55,6 @@ tools:
       valuefile: values.yaml
       path: helm/[[ app ]]
       repoURL: ${{repo-scaffolding.myapp.outputs.repoURL}}
+      token: [[ env GITHUB_TOKEN ]]
     imageRepo:
       user: [[ dockerUser ]]

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -17,6 +17,7 @@ tools:
       name: go-webapp-devstream-demo
       branch: main
       scmType: github
+      token: [[ env GITHUB_TOKEN ]]
     sourceRepo:
       org: devstream-io
       name: dtm-repo-scaffolding-golang-gin
@@ -30,6 +31,7 @@ tools:
       name: go-webapp-devstream-demo
       branch: main
       scmType: github
+      token: [[ env GITHUB_TOKEN ]]
     pipeline:
       configLocation: https://raw.githubusercontent.com/devstream-io/dtm-pipeline-templates/main/github-actions/workflows/main.yml
       language:
@@ -37,3 +39,4 @@ tools:
         framework: gin
       imageRepo:
         user: [[ ImageRepoUser ]]
+        password: [[ env IMAGE_REPO_PASSWORD ]]

--- a/internal/pkg/configmanager/pipelineDefault.go
+++ b/internal/pkg/configmanager/pipelineDefault.go
@@ -84,6 +84,7 @@ func pipelineArgocdAppGenerator(options RawOptions, globalVars *pipelineGlobalOp
 		if _, repoURLExist := sourceMap["repoURL"]; !repoURLExist {
 			sourceMap["repoURL"] = globalVars.Repo.GetCloneURL()
 			sourceMap["repoBranch"] = globalVars.Repo.Branch
+			sourceMap["token"] = globalVars.Repo.Token
 		}
 		options["source"] = sourceMap
 	} else {
@@ -92,6 +93,7 @@ func pipelineArgocdAppGenerator(options RawOptions, globalVars *pipelineGlobalOp
 			"path":       fmt.Sprintf("helm/%s", globalVars.AppName),
 			"repoURL":    string(globalVars.Repo.GetCloneURL()),
 			"repoBranch": globalVars.Repo.Branch,
+			"token":      globalVars.Repo.Token,
 		}
 	}
 	// config imageRepo default options

--- a/internal/pkg/configmanager/pipelineDefault_test.go
+++ b/internal/pkg/configmanager/pipelineDefault_test.go
@@ -90,6 +90,7 @@ var _ = Describe("pipelineArgocdAppGenerator func", func() {
 				"path":       "helm/test_app",
 				"repoURL":    "https://scm.test.com",
 				"repoBranch": "testBranch",
+				"token":      "",
 			},
 			"imageRepo": RawOptions{
 				"owner": "test_user",

--- a/internal/pkg/plugin/argocdapp/argocdapp.go
+++ b/internal/pkg/plugin/argocdapp/argocdapp.go
@@ -25,6 +25,7 @@ func pushArgocdConfigFiles(rawOptions configmanager.RawOptions) error {
 	repoInfo := &git.RepoInfo{
 		CloneURL: git.ScmURL(opts.Source.RepoURL),
 		Branch:   opts.Source.RepoBranch,
+		Token:    opts.Source.Token,
 	}
 	scmClient, err := scm.NewClientWithAuth(repoInfo)
 	if err != nil {

--- a/internal/pkg/plugin/argocdapp/options.go
+++ b/internal/pkg/plugin/argocdapp/options.go
@@ -47,6 +47,7 @@ type source struct {
 	Path       string `mapstructure:"path" validate:"required"`
 	RepoURL    string `mapstructure:"repoURL" validate:"required"`
 	RepoBranch string `mapstructure:"repoBranch"`
+	Token      string `mapstructure:"token"`
 }
 
 // / newOptions create options by raw options

--- a/internal/pkg/plugin/gitlabci/options_test.go
+++ b/internal/pkg/plugin/gitlabci/options_test.go
@@ -54,8 +54,9 @@ var _ = Describe("action struct", func() {
 				"ImageRepoDockerSecret": "image-repo-auth",
 				"RepoType":              "gitlab",
 				"imageRepo": map[string]interface{}{
-					"url":  "exmaple.com",
-					"user": "test_user",
+					"url":      "exmaple.com",
+					"user":     "test_user",
+					"password": "",
 				},
 				"dingTalk":            nilDingTalkConfig,
 				"DingTalkSecretKey":   "DINGTALK_SECURITY_VALUE",

--- a/internal/pkg/plugin/installer/ci/ci_test.go
+++ b/internal/pkg/plugin/installer/ci/ci_test.go
@@ -52,8 +52,9 @@ var _ = Describe("PipelineConfig struct", func() {
 				"ImageRepoSecret":       "IMAGE_REPO_SECRET",
 				"ImageRepoDockerSecret": "image-repo-auth",
 				"imageRepo": map[string]interface{}{
-					"url":  "exmaple.com",
-					"user": "test_user",
+					"url":      "exmaple.com",
+					"user":     "test_user",
+					"password": "",
 				},
 				"dingTalk":            nilDingTalkConfig,
 				"DingTalkSecretKey":   "DINGTALK_SECURITY_VALUE",
@@ -94,8 +95,9 @@ var _ = Describe("PipelineConfig struct", func() {
 			"StepGlobalVars":        "",
 			"RepoType":              "gitlab",
 			"imageRepo": map[string]interface{}{
-				"url":  "exmaple.com",
-				"user": "test_user",
+				"url":      "exmaple.com",
+				"user":     "test_user",
+				"password": "",
 			},
 			"dingTalk":           emptyDingtalk,
 			"sonarqube":          emptySonar,

--- a/internal/pkg/plugin/installer/ci/step/github.go
+++ b/internal/pkg/plugin/installer/ci/step/github.go
@@ -1,12 +1,9 @@
 package step
 
 import (
-	"os"
-
 	"github.com/devstream-io/devstream/pkg/util/jenkins"
 	"github.com/devstream-io/devstream/pkg/util/log"
 	"github.com/devstream-io/devstream/pkg/util/scm"
-	"github.com/devstream-io/devstream/pkg/util/scm/github"
 )
 
 const (
@@ -15,6 +12,7 @@ const (
 
 type GithubStepConfig struct {
 	RepoOwner string `mapstructure:"repoOwner"`
+	Token     string `mapstructure:"token"`
 }
 
 func (g *GithubStepConfig) GetJenkinsPlugins() []*jenkins.JenkinsPlugin {
@@ -31,7 +29,7 @@ func (g *GithubStepConfig) ConfigJenkins(jenkinsClient jenkins.JenkinsAPI) (*jen
 	err := jenkinsClient.CreatePasswordCredential(
 		githubCredentialName,
 		g.RepoOwner,
-		os.Getenv(github.TokenEnvKey),
+		g.Token,
 	)
 	if err != nil {
 		log.Debugf("jenkins preinstall github credentials failed: %s", err)
@@ -52,5 +50,6 @@ func (g *GithubStepConfig) ConfigSCM(client scm.ClientOperation) error {
 func newGithubStep(config *StepGlobalOption) *GithubStepConfig {
 	return &GithubStepConfig{
 		RepoOwner: config.RepoInfo.GetRepoOwner(),
+		Token:     config.RepoInfo.Token,
 	}
 }

--- a/internal/pkg/plugin/installer/ci/step/gitlab.go
+++ b/internal/pkg/plugin/installer/ci/step/gitlab.go
@@ -1,8 +1,6 @@
 package step
 
 import (
-	"os"
-
 	"github.com/devstream-io/devstream/pkg/util/jenkins"
 	"github.com/devstream-io/devstream/pkg/util/log"
 	"github.com/devstream-io/devstream/pkg/util/scm"
@@ -18,6 +16,7 @@ type GitlabStepConfig struct {
 	SSHPrivateKey string `mapstructure:"sshPrivateKey"`
 	RepoOwner     string `mapstructure:"repoOwner"`
 	BaseURL       string `mapstructure:"baseURL"`
+	Token         string `mapstructure:"token"`
 }
 
 func (g *GitlabStepConfig) GetJenkinsPlugins() []*jenkins.JenkinsPlugin {
@@ -42,7 +41,7 @@ func (g *GitlabStepConfig) ConfigJenkins(jenkinsClient jenkins.JenkinsAPI) (*jen
 		}
 	}
 	// 2. create gitlab connection by casc
-	err := jenkinsClient.CreateGiltabCredential(gitlabCredentialName, os.Getenv("GITLAB_TOKEN"))
+	err := jenkinsClient.CreateGiltabCredential(gitlabCredentialName, g.Token)
 	if err != nil {
 		log.Debugf("jenkins preinstall gitlab credentials failed: %s", err)
 		return nil, err
@@ -65,5 +64,6 @@ func newGitlabStep(config *StepGlobalOption) *GitlabStepConfig {
 		SSHPrivateKey: config.RepoInfo.SSHPrivateKey,
 		RepoOwner:     config.RepoInfo.GetRepoOwner(),
 		BaseURL:       config.RepoInfo.BaseURL,
+		Token:         config.RepoInfo.Token,
 	}
 }

--- a/internal/pkg/plugin/jenkinspipeline/jenkins.go
+++ b/internal/pkg/plugin/jenkinspipeline/jenkins.go
@@ -2,7 +2,6 @@ package jenkinspipeline
 
 import (
 	"errors"
-	"os"
 
 	"github.com/devstream-io/devstream/pkg/util/jenkins"
 	"github.com/devstream-io/devstream/pkg/util/k8s"
@@ -18,7 +17,8 @@ const (
 
 type jenkinsOption struct {
 	URL           string `mapstructure:"url" validate:"required,url"`
-	User          string `mapstructure:"user"`
+	User          string `mapstructure:"user" validate:"required"`
+	Password      string `mapstructure:"password" validate:"required"`
 	Namespace     string `mapstructure:"namespace"`
 	EnableRestart bool   `mapstructure:"enableRestart"`
 	Offline       bool   `mapstructure:"offline"`
@@ -40,13 +40,12 @@ func (j *jenkinsOption) newClient() (jenkins.JenkinsAPI, error) {
 }
 
 func (j *jenkinsOption) getBasicAuth() (*jenkins.BasicAuth, error) {
-	jenkinsPassword := os.Getenv(jenkinsPasswordEnvKey)
 	// 1. check username is set and has env password
-	if j.User != "" && jenkinsPassword != "" {
+	if j.User != "" && j.Password != "" {
 		log.Debugf("jenkins get auth token from env")
 		return &jenkins.BasicAuth{
 			Username: j.User,
-			Password: jenkinsPassword,
+			Password: j.Password,
 		}, nil
 	}
 	// 2. if not set, get user and password from secret

--- a/internal/pkg/plugin/jenkinspipeline/jenkins_test.go
+++ b/internal/pkg/plugin/jenkinspipeline/jenkins_test.go
@@ -25,30 +25,21 @@ var _ = Describe("jenkinsOption struct", func() {
 			URL:       url,
 			User:      user,
 			Namespace: namespace,
+			Password:  "changeme",
 		}
 	})
 	var (
-		existEnvPassword, testPassword string
+		testPassword string
 	)
 
-	BeforeEach(func() {
-		existEnvPassword = os.Getenv(jenkinsPasswordEnvKey)
-		err := os.Unsetenv(jenkinsPasswordEnvKey)
-		Expect(err).Error().ShouldNot(HaveOccurred())
-		testPassword = "test"
-	})
-
 	Context("getBasicAuth method", func() {
-		BeforeEach(func() {
-			os.Setenv(jenkinsPasswordEnvKey, testPassword)
-		})
 		When("env password is setted", func() {
 			It("should work normal", func() {
 				auth, err := opt.getBasicAuth()
 				Expect(err).Error().ShouldNot(HaveOccurred())
 				Expect(auth).ShouldNot(BeNil())
 				Expect(auth.Username).Should(Equal(user))
-				Expect(auth.Password).Should(Equal(testPassword))
+				Expect(auth.Password).Should(Equal("changeme"))
 			})
 		})
 	})
@@ -135,10 +126,5 @@ var _ = Describe("jenkinsOption struct", func() {
 				Expect(auth.Password).Should(Equal("test_pass"))
 			})
 		})
-	})
-	AfterEach(func() {
-		if existEnvPassword != "" {
-			os.Setenv(jenkinsPasswordEnvKey, existEnvPassword)
-		}
 	})
 })

--- a/internal/pkg/plugin/jenkinspipeline/validate_test.go
+++ b/internal/pkg/plugin/jenkinspipeline/validate_test.go
@@ -6,9 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/devstream-io/devstream/pkg/util/scm/github"
-	"github.com/devstream-io/devstream/pkg/util/scm/gitlab"
 )
 
 var _ = Describe("setDefault func", func() {
@@ -62,33 +59,15 @@ var _ = Describe("setDefault func", func() {
 
 var _ = Describe("validate func", func() {
 	var (
-		githubToken, gitlabToken string
-	)
-	BeforeEach(func() {
-		githubToken = os.Getenv(github.TokenEnvKey)
-		gitlabToken = os.Getenv(gitlab.TokenEnvKey)
-		err := os.Unsetenv(github.TokenEnvKey)
-		Expect(err).Error().ShouldNot(HaveOccurred())
-		err = os.Unsetenv(gitlab.TokenEnvKey)
-		Expect(err).Error().ShouldNot(HaveOccurred())
-	})
-	AfterEach(func() {
-		if githubToken != "" {
-			os.Setenv(github.TokenEnvKey, githubToken)
-		}
-		if gitlabToken != "" {
-			os.Setenv(gitlab.TokenEnvKey, gitlabToken)
-		}
-	})
-	var (
-		jenkinsUser, jenkinsURL, jenkinsFilePath, projectURL, repoType string
-		options, projectRepo, pipeline                                 map[string]interface{}
+		jenkinsUser, jenkinsURL, jenkinsFilePath, projectURL, repoType, githubToken string
+		options, projectRepo, pipeline                                              map[string]interface{}
 	)
 	BeforeEach(func() {
 		jenkinsUser = "test"
 		jenkinsURL = "http://test.jenkins.com/"
 		projectURL = "https://test.gitlab.com/test/test_project"
 		jenkinsFilePath = "http://raw.content.com/Jenkinsfile"
+		githubToken = "github_token"
 		pipeline = map[string]interface{}{
 			"configLocation": jenkinsFilePath,
 		}
@@ -100,11 +79,13 @@ var _ = Describe("validate func", func() {
 		options = map[string]interface{}{
 			"jobName": "test",
 			"jenkins": map[string]interface{}{
-				"url":  jenkinsURL,
-				"user": jenkinsUser,
+				"url":      jenkinsURL,
+				"user":     jenkinsUser,
+				"password": "changeme",
 			},
 			"scm": map[string]interface{}{
-				"url": projectURL,
+				"url":   projectURL,
+				"token": githubToken,
 			},
 			"pipeline":    pipeline,
 			"projectRepo": projectRepo,
@@ -138,9 +119,9 @@ var _ = Describe("validate func", func() {
 				"name":    "test",
 				"owner":   "test_user",
 				"branch":  "main",
+				"token":   githubToken,
 			}
 			options["scm"] = projectRepo
-			os.Setenv(github.TokenEnvKey, "test_env")
 		})
 		It("should return error", func() {
 			_, err := validateJenkins(options)
@@ -157,9 +138,9 @@ var _ = Describe("validate func", func() {
 				"name":    "test",
 				"owner":   "test_user",
 				"branch":  "main",
+				"token":   githubToken,
 			}
 			options["scm"] = projectRepo
-			os.Setenv(github.TokenEnvKey, "test_env")
 		})
 		It("should return nil error", func() {
 			_, err := validateJenkins(options)

--- a/internal/pkg/show/config/plugins/ci-generic.yaml
+++ b/internal/pkg/show/config/plugins/ci-generic.yaml
@@ -17,3 +17,5 @@ tools:
       branch: YOUR_REPO_BRANCH
       # support github/gitlab for now
       scmType: github
+      # scm repo token
+      token: YOUR_REPO_TOKEN

--- a/internal/pkg/show/config/plugins/github-actions.yaml
+++ b/internal/pkg/show/config/plugins/github-actions.yaml
@@ -12,6 +12,8 @@ tools:
       url: git@github.com/root/test-exmaple.git
       # project branch, default branch will be main
       branch: YOUR_PROJECT_BRANCH
+      # scm repo token
+      token: YOUR_REPO_TOKEN
     pipeline:
       # workFlowfilePath is the location of workflows, it can be remote or local
       configLocation: https://raw.githubusercontent.com/devstream-io/devstream/main/staging/dtm-github-action-example/general
@@ -23,6 +25,8 @@ tools:
         url: http://harbor.example.com:80
         # image repo user name
         user: admin
+        # image repo password
+        password: YOUR_IMAGE_REPO_PASSWORD
       dingTalk:
         # dingtalk robot name
         name: YOUR_DINGTALK_ROBOT_NAME

--- a/internal/pkg/show/config/plugins/gitlab-ci.yaml
+++ b/internal/pkg/show/config/plugins/gitlab-ci.yaml
@@ -12,6 +12,8 @@ tools:
       url: git@gitlab.com/root/test-exmaple.git
       # project branch, default branch will be master
       branch: YOUR_PROJECT_BRANCH
+      # scm repo token
+      token: YOUR_REPO_TOKEN
     pipeline:
       # workFlowfilePath is the location of workflows, it can be remote or local
       configLocation: .gitlabci.yml
@@ -23,3 +25,5 @@ tools:
         url: http://harbor.example.com:80
         # image repo user name
         user: admin
+        # image repo password
+        password: YOUR_IMAGE_REPO_PASSWORD

--- a/internal/pkg/show/config/plugins/jenkins-pipeline.yaml
+++ b/internal/pkg/show/config/plugins/jenkins-pipeline.yaml
@@ -16,6 +16,8 @@ tools:
       namespace: jenkins
       # restart jenkins if true for plugin install
       enableRestart: false
+      # jenkins login password
+      password: JENKINS_PASSWORD
       # if offline is true, jenkins-pipeline will not install jenkins plugins and share library
       # it will use a local Jenkinsfile for jenkins-pipeline
       offline: false
@@ -26,6 +28,8 @@ tools:
       apiURL: http://gitlab.example.com
       # project branch, if your repo type is github, default branch will be main. if your repo type is gitlab, default branch will be master
       branch: YOUR_PROJECT_BRANCH
+      # scm repo token
+      token: YOUR_REPO_TOKEN
     pipeline:
       # jobName is jenkins's job name; <jobFolder/jobName> or <jobName>; e.g. jobs/test-job, test-job, jobs2/test-job
       jobName: test-job
@@ -39,6 +43,8 @@ tools:
         url: http://harbor.example.com:80
         # image repo user name
         user: admin
+        # image repo password
+        password: YOUR_IMAGE_REPO_PASSWORD
       dingTalk:
         # dingtalk robot name
         name: YOUR_DINGTALK_ROBOT_NAME

--- a/internal/pkg/show/config/plugins/repo-scaffolding.yaml
+++ b/internal/pkg/show/config/plugins/repo-scaffolding.yaml
@@ -15,6 +15,8 @@ tools:
       branch: YOUR_DESTINATION_REPO_MAIN_BRANCH
       # scmType is the type of repo to push, support github|gitlab
       scmType: YOUR_DESTINATION_REPO_TYPE
+      # scm repo token
+      token: YOUR_REPO_TOKEN
     # sourceRepo is the template repo location, support github only
     sourceRepo:
       org: YOUR_TEMPLATE_REPO_ORG

--- a/internal/pkg/show/config/plugins/trello.yaml
+++ b/internal/pkg/show/config/plugins/trello.yaml
@@ -20,3 +20,5 @@ tools:
       scmType: YOUR_REPO_TYPE
       # project branch
       branch: YOUR_PROJECT_BRANCH
+      # scm repo token
+      token: YOUR_REPO_TOKEN

--- a/internal/pkg/show/config/templates/apps.yaml
+++ b/internal/pkg/show/config/templates/apps.yaml
@@ -19,6 +19,7 @@ apps:
     framework: django
   repo:
     url: github.com/[[ GITHUB_USER ]]/myapp1
+    token: [[ env GITHUB_TOKEN ]]
   repoTemplate:
     url: github.com/devstream-io/dtm-repo-scaffolding-python-flask
   ci:
@@ -26,6 +27,7 @@ apps:
     options:
       imageRepo:
         user: [[ DOCKERHUB_USER ]]
+        password: [[ env IMAGE_REPO_PASSWORD ]]
   cd:
   - type: argocdapp
 - name: myapp2
@@ -34,6 +36,7 @@ apps:
     framework: gin
   repo:
     url: github.com/[[ GITHUB_USER ]]/myapp2
+    token: [[ env GITHUB_TOKEN ]]
   repoTemplate:
     url: github.com/devstream-io/dtm-repo-scaffolding-golang-gin
   ci:
@@ -41,5 +44,6 @@ apps:
     options:
       imageRepo:
         user: [[ DOCKERHUB_USER ]]
+        password: [[ env IMAGE_REPO_PASSWORD ]]
   cd:
   - type: argocdapp

--- a/internal/pkg/show/config/templates/gitops.yaml
+++ b/internal/pkg/show/config/templates/gitops.yaml
@@ -17,6 +17,7 @@ tools:
       name: [[ app ]]
       branch: main
       scmType: github
+      token: [[ env GITHUB_TOKEN ]]
     sourceRepo:
       org: devstream-io
       name: dtm-repo-scaffolding-python-flask
@@ -29,6 +30,7 @@ tools:
       owner: [[ githubUser ]]
       name:  [[ app ]]
       scmType: github
+      token: [[ env GITHUB_TOKEN ]]
     pipeline:
       configLocation: https://raw.githubusercontent.com/devstream-io/dtm-pipeline-templates/main/github-actions/workflows/main.yml
       language:
@@ -36,6 +38,7 @@ tools:
         framework: flask
       imageRepo:
         user: [[ dockerUser ]]
+        password: [[ env IMAGE_REPO_PASSWORD ]]
 - name: helm-installer
   instanceID: argocd
 - name: argocdapp
@@ -52,5 +55,6 @@ tools:
       valuefile: values.yaml
       path: helm/[[ app ]]
       repoURL: ${{repo-scaffolding.myapp.outputs.repoURL}}
+      token: [[ env GITHUB_TOKEN ]]
     imageRepo:
       user: [[ dockerUser ]]

--- a/internal/pkg/show/config/templates/quickstart.yaml
+++ b/internal/pkg/show/config/templates/quickstart.yaml
@@ -17,6 +17,7 @@ tools:
       name: go-webapp-devstream-demo
       branch: main
       scmType: github
+      token: [[ env GITHUB_TOKEN ]]
     sourceRepo:
       org: devstream-io
       name: dtm-repo-scaffolding-golang-gin
@@ -30,6 +31,7 @@ tools:
       name: go-webapp-devstream-demo
       branch: main
       scmType: github
+      token: [[ env GITHUB_TOKEN ]]
     pipeline:
       configLocation: https://raw.githubusercontent.com/devstream-io/dtm-pipeline-templates/main/github-actions/workflows/main.yml
       language:
@@ -37,3 +39,4 @@ tools:
         framework: gin
       imageRepo:
         user: [[ ImageRepoUser ]]
+        password: [[ env IMAGE_REPO_PASSWORD ]]

--- a/pkg/util/scm/git/repoinfo.go
+++ b/pkg/util/scm/git/repoinfo.go
@@ -3,7 +3,6 @@ package git
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/devstream-io/devstream/pkg/util/log"
@@ -12,10 +11,6 @@ import (
 
 type ScmURL string
 
-const (
-	privateSSHKeyEnv = "REPO_SSH_PRIVATEKEY"
-)
-
 type RepoInfo struct {
 	// repo detail fields
 	Owner    string `yaml:"owner" mapstructure:"owner,omitempty"`
@@ -23,6 +18,7 @@ type RepoInfo struct {
 	Repo     string `yaml:"name" mapstructure:"name,omitempty"`
 	Branch   string `yaml:"branch" mapstructure:"branch,omitempty"`
 	RepoType string `yaml:"scmType" mapstructure:"scmType,omitempty"`
+	Token    string `yaml:"token" mapstructure:"token,omitempty"`
 
 	// url fields
 	APIURL   string `yaml:"apiURL" mapstructure:"apiURL,omitempty"`
@@ -179,9 +175,6 @@ func (r *RepoInfo) updateFieldsFromURLField() error {
 	r.Repo = repoName
 	// 3. if scm.branch is not configured, just use repo's default branch
 	r.Branch = r.getBranchWithDefault()
-	if r.SSHPrivateKey == "" {
-		r.SSHPrivateKey = os.Getenv(privateSSHKeyEnv)
-	}
 	return nil
 }
 
@@ -195,19 +188,6 @@ func (r *RepoInfo) checkValid() error {
 	}
 	if r.Repo == "" {
 		return fmt.Errorf("git name field must be configured")
-	}
-	// check token is configured
-	if r.NeedAuth {
-		switch r.RepoType {
-		case "gitlab":
-			if os.Getenv("GITLAB_TOKEN") == "" {
-				return fmt.Errorf("gitlab repo should set env GITLAB_TOKEN")
-			}
-		case "github":
-			if os.Getenv("GITHUB_TOKEN") == "" {
-				return fmt.Errorf("github repo should set env GITHUB_TOKEN")
-			}
-		}
 	}
 	return nil
 }

--- a/pkg/util/scm/git/repoinfo_test.go
+++ b/pkg/util/scm/git/repoinfo_test.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"fmt"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -157,61 +156,6 @@ var _ = Describe("RepoInfo struct", func() {
 	})
 
 	Context("checkValid method", func() {
-		var (
-			gitlabEnv, githubEnv string
-		)
-		BeforeEach(func() {
-			gitlabEnv = os.Getenv("GITLAB_TOKEN")
-			githubEnv = os.Getenv("GITHUB_TOKEN")
-			os.Unsetenv("GITLAB_TOKEN")
-			os.Unsetenv("GITHUB_TOKEN")
-		})
-		When("gitlab token is not configured", func() {
-			BeforeEach(func() {
-				repoInfo = &RepoInfo{
-					Owner:    "test",
-					RepoType: "gitlab",
-					NeedAuth: true,
-					Repo:     "test",
-				}
-			})
-			It("should return err", func() {
-				err := repoInfo.checkValid()
-				Expect(err).Error().Should(HaveOccurred())
-				Expect(err.Error()).Should(ContainSubstring("gitlab repo should set env GITLAB_TOKEN"))
-			})
-		})
-		When("github token is not configured", func() {
-			BeforeEach(func() {
-				repoInfo = &RepoInfo{
-					Owner:    "test",
-					RepoType: "github",
-					NeedAuth: true,
-					Repo:     "test",
-				}
-			})
-			It("should return err", func() {
-				err := repoInfo.checkValid()
-				Expect(err).Error().Should(HaveOccurred())
-				Expect(err.Error()).Should(ContainSubstring("github repo should set env GITHUB_TOKEN"))
-			})
-		})
-		When("token is configured", func() {
-			BeforeEach(func() {
-				repoInfo = &RepoInfo{
-					Owner:    "test",
-					RepoType: "github",
-					NeedAuth: true,
-					Repo:     "test",
-				}
-				os.Setenv("GITHUB_TOKEN", "test")
-			})
-			It("should return err", func() {
-				err := repoInfo.checkValid()
-				Expect(err).Error().ShouldNot(HaveOccurred())
-			})
-		})
-
 		When("org and owner are all exist", func() {
 			BeforeEach(func() {
 				repoInfo = &RepoInfo{
@@ -239,14 +183,6 @@ var _ = Describe("RepoInfo struct", func() {
 			})
 		})
 
-		AfterEach(func() {
-			if githubEnv != "" {
-				os.Setenv("GITHUB_TOKEN", githubEnv)
-			}
-			if gitlabEnv != "" {
-				os.Setenv("GITLAB_TOKEN", gitlabEnv)
-			}
-		})
 	})
 
 	Context("Encode method", func() {

--- a/pkg/util/scm/github/github.go
+++ b/pkg/util/scm/github/github.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/google/go-github/v42/github"
 	"golang.org/x/oauth2"
@@ -17,7 +16,6 @@ const (
 	defaultCommitAuthor      = "devstream"
 	defaultCommitAuthorEmail = "devstream@merico.dev"
 	repoPlaceHolderFileName  = ".placeholder"
-	TokenEnvKey              = "GITHUB_TOKEN"
 )
 
 var (
@@ -66,23 +64,18 @@ func NewClient(option *git.RepoInfo) (*Client, error) {
 	// Don't use `token := viper.GetString("github_token")` here,
 	// it will fail without calling `viper.BindEnv("github_token")` first.
 	// os.Getenv() function is more clear and reasonable here.
-	token := os.Getenv(TokenEnvKey)
-	if token == "" {
-		// github_token works well as GITHUB_TOKEN.
-		token = os.Getenv("github_token")
-	}
-	if token == "" {
-		retErr = fmt.Errorf("environment variable GITHUB_TOKEN is not set. Failed to initialize GitHub token. More info - " +
+	if option.Token == "" {
+		retErr = fmt.Errorf("config field scm.token is not set. Failed to initialize GitHub token. More info - " +
 			"https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token")
 		return nil, retErr
 	}
-	log.Debugf("Token: %s.", token)
+	log.Debugf("Token: %s.", option.Token)
 
 	tc := oauth2.NewClient(
 		context.TODO(),
 		oauth2.StaticTokenSource(
 			&oauth2.Token{
-				AccessToken: token,
+				AccessToken: option.Token,
 			},
 		),
 	)

--- a/pkg/util/scm/github/github_test.go
+++ b/pkg/util/scm/github/github_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -18,20 +17,6 @@ const (
 	// BaseURLPath is a non-empty Client.BaseURL path to use during tests,
 	// to ensure relative URLs are used for all endpoints.
 	BaseURLPath = "/api-v3"
-)
-
-var (
-	OptNotNeedAuth = &git.RepoInfo{
-		Owner: "",
-		Org:   "devstream-io",
-		Repo:  "dtm-repo-scaffolding-golang-gin",
-	}
-	OptNeedAuth = &git.RepoInfo{
-		Owner:    "",
-		Org:      "devstream-io",
-		Repo:     "dtm-repo-scaffolding-golang-gin",
-		NeedAuth: true,
-	}
 )
 
 type BaseTest struct {
@@ -106,18 +91,41 @@ func NewClientWithOption(opt *git.RepoInfo, severUrl string) (*Client, error) {
 }
 
 var _ = Describe("GitHub", func() {
+	var (
+		optNotNeedAuth, optNeedAuth, optNeedAuthWithToken *git.RepoInfo
+	)
+	BeforeEach(func() {
+		optNotNeedAuth = &git.RepoInfo{
+			Owner: "",
+			Org:   "devstream-io",
+			Repo:  "dtm-repo-scaffolding-golang-gin",
+		}
+		optNeedAuth = &git.RepoInfo{
+			Owner:    "",
+			Org:      "devstream-io",
+			Repo:     "dtm-repo-scaffolding-golang-gin",
+			NeedAuth: true,
+		}
+		optNeedAuthWithToken = &git.RepoInfo{
+			Owner:    "",
+			Org:      "devstream-io",
+			Repo:     "dtm-repo-scaffolding-golang-gin",
+			NeedAuth: true,
+			Token:    "token",
+		}
+	})
 	Context("Client with cacahe", func() {
 		var ghClient *Client
 		var err error
 
 		BeforeEach(func() {
-			ghClient, err = NewClient(OptNotNeedAuth)
+			ghClient, err = NewClient(optNotNeedAuth)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ghClient).NotTo(Equal(nil))
 		})
 
 		It("with cacahe client", func() {
-			ghClient, err = NewClient(OptNotNeedAuth)
+			ghClient, err = NewClient(optNotNeedAuth)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ghClient).NotTo(Equal(nil))
 		})
@@ -127,44 +135,24 @@ var _ = Describe("GitHub", func() {
 		var ghClient *Client
 		var err error
 		It("", func() {
-			ghClient, err = NewClient(OptNotNeedAuth)
+			ghClient, err = NewClient(optNotNeedAuth)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ghClient).NotTo(Equal(nil))
 		})
 	})
 
 	Context("Client with auth enabled but not github token", func() {
-		var existToken string
-		BeforeEach(func() {
-			existToken = os.Getenv("GITHUB_TOKEN")
-			err := os.Unsetenv("GITHUB_TOKEN")
-			Expect(err).NotTo(HaveOccurred())
-		})
-		It("", func() {
-			_, err := NewClient(OptNeedAuth)
+		It("should return err", func() {
+			_, err := NewClient(optNeedAuth)
 			Expect(err).To(HaveOccurred())
-		})
-		AfterEach(func() {
-			if existToken != "" {
-				err := os.Setenv("GITHUB_TOKEN", existToken)
-				Expect(err).NotTo(HaveOccurred())
-			}
 		})
 	})
 
 	Context("Client with auth enabled and github token", func() {
-		var ghClient *Client
-		var err error
-		BeforeEach(func() {
-			os.Setenv("GITHUB_TOKEN", "GITHUB_TOKEN")
-		})
-		It("", func() {
-			ghClient, err = NewClient(OptNeedAuth)
+		It("should return client", func() {
+			ghClient, err := NewClient(optNeedAuthWithToken)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ghClient).NotTo(Equal(nil))
-		})
-		AfterEach(func() {
-			os.Unsetenv("GITHUB_TOKEN")
 		})
 	})
 })

--- a/pkg/util/scm/gitlab/gitlab.go
+++ b/pkg/util/scm/gitlab/gitlab.go
@@ -2,7 +2,6 @@ package gitlab
 
 import (
 	"errors"
-	"os"
 
 	"github.com/xanzy/go-gitlab"
 
@@ -11,7 +10,6 @@ import (
 
 const (
 	DefaultGitlabHost = "https://gitlab.com"
-	TokenEnvKey       = "GITLAB_TOKEN"
 )
 
 type Client struct {
@@ -20,9 +18,8 @@ type Client struct {
 }
 
 func NewClient(options *git.RepoInfo) (*Client, error) {
-	token := os.Getenv(TokenEnvKey)
-	if token == "" {
-		return nil, errors.New("failed to read GITLAB_TOKEN from environment variable")
+	if options.Token == "" {
+		return nil, errors.New("config field scm.token is not setted")
 	}
 
 	c := &Client{}
@@ -30,9 +27,9 @@ func NewClient(options *git.RepoInfo) (*Client, error) {
 	var err error
 
 	if options.BaseURL == "" {
-		c.Client, err = gitlab.NewClient(token)
+		c.Client, err = gitlab.NewClient(options.Token)
 	} else {
-		c.Client, err = gitlab.NewClient(token, gitlab.WithBaseURL(options.BaseURL))
+		c.Client, err = gitlab.NewClient(options.Token, gitlab.WithBaseURL(options.BaseURL))
 	}
 	c.RepoInfo = options
 

--- a/pkg/util/scm/gitlab/gitlab_suite_test.go
+++ b/pkg/util/scm/gitlab/gitlab_suite_test.go
@@ -1,7 +1,6 @@
 package gitlab_test
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -9,7 +8,7 @@ import (
 )
 
 var (
-	existGitlabToken, apiRootPath string
+	apiRootPath string
 )
 
 func TestPlanmanager(t *testing.T) {
@@ -19,14 +18,4 @@ func TestPlanmanager(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	apiRootPath = "/api/v4/"
-	existGitlabToken := os.Getenv("GITLAB_TOKEN")
-	if existGitlabToken != "" {
-		os.Unsetenv("GITLAB_TOKEN")
-	}
-})
-
-var _ = AfterSuite(func() {
-	if existGitlabToken != "" {
-		os.Setenv("GITLAB_TOKEN", existGitlabToken)
-	}
 })

--- a/test/e2e/yaml/e2e-apps.yaml
+++ b/test/e2e/yaml/e2e-apps.yaml
@@ -22,6 +22,7 @@ apps:
   repo:
     org: [[ repoOwner ]]
     scmType: github
+    token: [[ env GITHUB_TOKEN ]]
   repoTemplate:
     url: github.com/devstream-io/dtm-repo-scaffolding-golang-gin
   ci:
@@ -29,5 +30,6 @@ apps:
     options:
       imageRepo:
         user: [[ imageRepoOwner ]]
+        password: [[ env IMAGE_REPO_PASSWORD ]]
   cd:
   - type: argocdapp

--- a/test/e2e/yaml/e2e-test-local.yaml
+++ b/test/e2e/yaml/e2e-test-local.yaml
@@ -21,6 +21,7 @@ tools:
       name: [[ repoName ]]
       branch: [[ defaultBranch ]]
       scmType: github
+      token: [[ env GITHUB_TOKEN ]]
     sourceRepo:
       org: devstream-io
       name: dtm-repo-scaffolding-golang-gin
@@ -33,6 +34,7 @@ tools:
       configLocation: [[ githubActionConfigLocation ]]
       imageRepo:
         user: [[ dockerRegistryUserName ]]
+        password: [[ env IMAGE_REPO_PASSWORD ]]
       language:
         name: go
         framework: gin
@@ -40,6 +42,7 @@ tools:
       org: ${{repo-scaffolding.golang-github.outputs.owner}}
       name: ${{repo-scaffolding.golang-github.outputs.repo}}
       branch: [[ defaultBranch ]]
+      token: [[ env GITHUB_TOKEN ]]
       scmType: github
 - name: helm-installer
   instanceID: argocd-001
@@ -57,5 +60,6 @@ tools:
       valuefile: values.yaml
       path: helm/${{repo-scaffolding.golang-github.outputs.repo}}
       repoURL: ${{repo-scaffolding.golang-github.outputs.repoURL}}
+      token: [[ env GITHUB_TOKEN ]]
     imageRepo:
       user: [[ dockerRegistryUserName ]]

--- a/test/e2e/yaml/e2e-tools.yaml
+++ b/test/e2e/yaml/e2e-tools.yaml
@@ -19,6 +19,7 @@ tools:
       org: [[ githubOrganization ]]
       name: [[ repoName ]]
       branch: [[ defaultBranch ]]
+      token: [[ env GITHUB_TOKEN ]]
       scmType: github
     sourceRepo:
       org: devstream-io
@@ -32,11 +33,13 @@ tools:
       configLocation: [[ githubActionConfigLocation ]]
       imageRepo:
         user: [[ dockerRegistryUserName ]]
+        password: [[ env IMAGE_REPO_PASSWORD ]]
       language:
         name: python
         framework: flask
     scm:
       org: [[ githubOrganization ]]
+      token: [[ env GITHUB_TOKEN ]]
       name: [[ repoName ]]
       branch: [[ defaultBranch ]]
       scmType: github
@@ -56,5 +59,6 @@ tools:
       valuefile: values.yaml
       path: helm/[[ repoName ]]
       repoURL: ${{repo-scaffolding.python-github.outputs.repoURL}}
+      token: [[ env GITHUB_TOKEN ]]
     imageRepo:
       user: [[ dockerRegistryUserName ]]


### PR DESCRIPTION
Signed-off-by: Meng JiaFeng <jiafeng.meng@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [ ] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [ ] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description
- BREAK CHANGE: now you should set `scm.token` instead of use env

- [ ] update docs for this config

## Related Issues
#1211 

## New Behavior (screenshots if needed)
![image](https://user-images.githubusercontent.com/13215800/209624127-dd51af2c-efc7-433b-a7a8-358b1455d6d4.png)
