### PR TITLE
fix: staging reposcaffolding using 80 port as default

### DIFF
--- a/staging/dtm-repo-scaffolding-golang-gin/Dockerfile.tpl
+++ b/staging/dtm-repo-scaffolding-golang-gin/Dockerfile.tpl
@@ -9,4 +9,4 @@ WORKDIR /app
 COPY --from=build-env /go/src/github.com/[[.Repo.Owner]]/[[.Repo.Name]]/app /app/
 CMD ["./app"]
 USER 1000
-EXPOSE 8080/tcp
+EXPOSE 80/tcp

--- a/staging/dtm-repo-scaffolding-golang-gin/cmd/_app_name_/main.go.tpl
+++ b/staging/dtm-repo-scaffolding-golang-gin/cmd/_app_name_/main.go.tpl
@@ -13,5 +13,5 @@ func main() {
 	router.GET("/albums/:id", album.GetAlbumByID)
 	router.POST("/albums", album.PostAlbums)
 
-	router.Run("localhost:8080")
+	router.Run("localhost:80")
 }

--- a/staging/dtm-repo-scaffolding-python-flask/Dockerfile.tpl
+++ b/staging/dtm-repo-scaffolding-python-flask/Dockerfile.tpl
@@ -11,4 +11,4 @@ COPY ./app /code/app
 
 USER 1000
 
-CMD ["gunicorn", "--conf", "app/gunicorn.conf.py", "--bind", "0.0.0.0:8080", "wsgi:app"]
+CMD ["gunicorn", "--conf", "app/gunicorn.conf.py", "--bind", "0.0.0.0:80", "wsgi:app"]


### PR DESCRIPTION
Signed-off-by: Meng JiaFeng <jiafeng.meng@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [ ] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [ ] My code has the necessary comments and documentation (if needed).
- [ ] I have added relevant tests

## Description
- All staging repo-scaffolding use same port 80

## Related Issues
<!--
Will this PR close any open issues? If yes, would you please mention the issue(s) here?
-->

## New Behavior (screenshots if needed)
<!--
Describe the newly updated behavior, if relevant.
-->
