### PR TITLE
feat: raise err when config env is not exist

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/Masterminds/semver v1.5.0
-	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/adlio/trello v1.9.0
 	github.com/argoproj/argo-cd/v2 v2.2.2
 	github.com/argoproj/gitops-engine v0.5.2
@@ -56,6 +55,7 @@ require (
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/Masterminds/squirrel v1.5.2 // indirect
 	github.com/Microsoft/go-winio v0.4.17 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect

--- a/pkg/util/template/client.go
+++ b/pkg/util/template/client.go
@@ -3,9 +3,8 @@ package template
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"text/template"
-
-	"github.com/Masterminds/sprig/v3"
 
 	"github.com/devstream-io/devstream/pkg/util/log"
 )
@@ -82,10 +81,22 @@ func (c *renderClient) newTemplateClient() *template.Template {
 	if !c.Option.IgnoreMissKeyError {
 		t = t.Option("missingkey=error")
 	}
-	// use sprig functions such as "env"
-	t.Funcs(sprig.TxtFuncMap())
+	t.Funcs(defaultFuncMap)
 	if c.Option.FuncMap != nil {
 		t.Funcs(c.Option.FuncMap)
 	}
 	return t
+}
+
+// defaultFuncMap is the default logic for templatge render func
+var defaultFuncMap = map[string]any{
+	"env": getEnvInTemplate,
+}
+
+func getEnvInTemplate(envKey string) (string, error) {
+	envVal := os.Getenv(envKey)
+	if envVal == "" {
+		return "", fmt.Errorf("template can't get environment variable %s, maybe you should set this environment first", envKey)
+	}
+	return envVal, nil
 }

--- a/pkg/util/template/client_test.go
+++ b/pkg/util/template/client_test.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"text/template"
 
@@ -106,5 +107,48 @@ var _ = Describe("renderClient", func() {
 			Expect(err.Error()).Should(ContainSubstring("render template: default_template"))
 		})
 	})
+})
 
+var _ = Describe("template default funcs", func() {
+	Context("getEnvInTemplate func", func() {
+		var (
+			tokenKey string
+			existVal string
+		)
+		BeforeEach(func() {
+			tokenKey = "TEMPLATE_ENV_TEST"
+			existVal = os.Getenv(tokenKey)
+			if existVal != "" {
+				err := os.Unsetenv(tokenKey)
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+		})
+		When("env not exist", func() {
+			BeforeEach(func() {
+				err := os.Unsetenv(tokenKey)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+			It("should return err", func() {
+				_, err := getEnvInTemplate(tokenKey)
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).Should(Equal("template can't get environment variable TEMPLATE_ENV_TEST, maybe you should set this environment first"))
+			})
+		})
+		When("env exist", func() {
+			BeforeEach(func() {
+				err := os.Setenv(tokenKey, "test")
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+			It("should return err", func() {
+				data, err := getEnvInTemplate(tokenKey)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(data).Should(Equal("test"))
+			})
+		})
+		AfterEach(func() {
+			if existVal != "" {
+				os.Setenv(tokenKey, existVal)
+			}
+		})
+	})
 })


### PR DESCRIPTION
Signed-off-by: Meng JiaFeng <jiafeng.meng@merico.dev>

## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
- we use `[[ env ENV_KEY ]]` for the config option, for now, this pr will raise an exception when env value is not exist

## Related Issues
#1211

## New Behavior (screenshots if needed)
when env is not set
![image](https://user-images.githubusercontent.com/13215800/209799936-4be7746d-cccf-4277-a090-09e282e96af0.png)

