### PR TITLE
Fix The CI Error With Wrong Golang Version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,22 +7,17 @@ on:
   pull_request:
     branches:
       - main
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20.3"
           cache: true
-
-      - name: Check out code
-        uses: actions/checkout@v3
-
       - name: Run tests
         run: go test -v ./...
-
       - name: Build project
         run: make build


### PR DESCRIPTION
## Pre-Checklist

Note: please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/devstream-io/devstream/blob/main/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests

## Description
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

Github Actions looks Golang version 1.20 as 1.2, so the workflow failed.

1.20 -> "1.20.3" works fine.

Thanks to @aFlyBird0 very much for the helping in the fix progress.